### PR TITLE
Github Issue 45 - Seed Data through migrations in the API project 

### DIFF
--- a/src/Api/Data/Seed/DatabaseSeeder.cs
+++ b/src/Api/Data/Seed/DatabaseSeeder.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Services.Administration;
+using Services.Financial;
+using Services.Inventory;
+using Services.Purchasing;
+using Services.Sales;
+using Services.Security;
+
+namespace Api.Data.Seed
+{
+    public class DatabaseSeeder
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public DatabaseSeeder(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public void Seed()
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var adminService = scope.ServiceProvider.GetRequiredService<IAdministrationService>();
+            var financialService = scope.ServiceProvider.GetRequiredService<IFinancialService>();
+            var salesService = scope.ServiceProvider.GetRequiredService<ISalesService>();
+            var purchasingService = scope.ServiceProvider.GetRequiredService<IPurchasingService>();
+            var inventoryService = scope.ServiceProvider.GetRequiredService<IInventoryService>();
+            var securityService = scope.ServiceProvider.GetRequiredService<ISecurityService>();
+
+            var initializer = new Initializer(
+                adminService, 
+                financialService, 
+                salesService, 
+                purchasingService, 
+                inventoryService, 
+                securityService
+            );
+
+            var success = initializer.Setup();
+
+            if (success)
+            {
+                Console.WriteLine("Database seeding completed successfully.");
+            }
+            else
+            {
+                Console.WriteLine("Database seeding failed. Check logs for details.");
+            }
+        }
+    }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -2,6 +2,7 @@ using System;
 using Api.ActionFilters;
 using Api.Data;
 using Api.Data.Repositories;
+using Api.Data.Seed;
 using Api.Extensions;
 using Api.Service;
 using Microsoft.AspNetCore.Builder;
@@ -72,6 +73,8 @@ builder.Services.AddScoped(typeof(Services.Administration.IAdministrationService
 builder.Services.AddScoped(typeof(Services.Security.ISecurityService), typeof(Services.Security.SecurityService));
 builder.Services.AddScoped(typeof(Services.TaxSystem.ITaxService), typeof(Services.TaxSystem.TaxService));
 
+//seed the database
+builder.Services.AddScoped<DatabaseSeeder>();
 
 var app = builder.Build();
 
@@ -106,6 +109,9 @@ using (var scope = app.Services.CreateScope())
     {
         identityDbContext.Database.Migrate();
     }
+
+    var seeder = services.GetRequiredService<DatabaseSeeder>();
+    seeder.Seed();
 }
 
 app.Run();


### PR DESCRIPTION
Done by Brett, Helen, and Sukhraj. 

15 hours total spent researching, debugging, and testing. 

Solution: To create a new DatabaseSeeder class inside of Api/Data/Seed and leverage previous coding architecture that used the data initializer that is not called in the DatabaseSeeder. Inside of the Program.cs, we added the scope of the DatabaseSeeder, and then called the seeder after migrations. The seed will only be called once upon initialization. 

No bugs introduced.