### PR TITLE
Connect Chart of Accounts create/edit/delete to API and database

### DIFF
--- a/src/AccountGoWeb/Components/Pages/Financial/ChartOfAccounts.razor
+++ b/src/AccountGoWeb/Components/Pages/Financial/ChartOfAccounts.razor
@@ -6,6 +6,7 @@
 @using Microsoft.Net.Http.Headers
 @inject IHttpClientFactory ClientFactory
 @inject Microsoft.JSInterop.IJSRuntime JSRuntime
+@inject IConfiguration Configuration
 
 <PageTitle>Chart of Accounts</PageTitle>
 
@@ -218,7 +219,7 @@ else
     {
         try
         {
-            string apiUrl = Environment.GetEnvironmentVariable("APIURL") ?? "http://localhost:8001/api/";
+            string? apiUrl = Configuration["ApiUrl"];
             var client = ClientFactory.CreateClient();
 
             var response = await client.GetAsync($"{apiUrl}financials/accounts");
@@ -246,7 +247,10 @@ else
       // Open Add Modal
     private void OpenAddModal()
     {
-        selectedAccount = new AccountViewModel();
+        selectedAccount = new AccountViewModel{
+            AccountClassId = 1, // Assets
+            CompanyId = 1
+        };
         errorMessage = string.Empty;
         isAddModalVisible = true;
     }
@@ -290,7 +294,7 @@ else
     }
 
     // Add or Update Account
-    private void SaveAccount()
+    private async Task SaveAccount()
     {
         if (selectedAccount == null)
         {
@@ -304,47 +308,56 @@ else
             return;
         }
 
-        if (isEditModalVisible)
+        try
         {
-            // Edit existing account locally
-            var account = accounts.FirstOrDefault(a => a.AccountCode == selectedAccount.AccountCode);
-            if (account != null)
+            string? apiUrl = Configuration["ApiUrl"];
+            var client = ClientFactory.CreateClient();
+
+            if (isEditModalVisible)
             {
-                account.AccountName = selectedAccount.AccountName;
-                account.TotalBalance = selectedAccount.TotalBalance;
-                account.TotalDebitBalance = selectedAccount.TotalDebitBalance;
-                account.TotalCreditBalance = selectedAccount.TotalCreditBalance;
+                // Edit existing account in DB
+                var response = await client.PutAsJsonAsync($"{apiUrl}financials/updateaccount/{selectedAccount.AccountCode}", selectedAccount);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    await LoadAccountsFromApi();
+                    CloseModal();
+                }
+                else
+                {
+                    errorMessage = $"Failed to update account: {response.StatusCode}";
+                }
             }
             else
             {
-                errorMessage = "Account not found.";
+                if (accounts.Any(a => a.AccountCode == selectedAccount.AccountCode))
+                {
+                    errorMessage = "An account with this Account Code already exists.";
+                    return;
+                }
+
+                var response = await client.PostAsJsonAsync($"{apiUrl}financials/addaccount", selectedAccount);
+                if (response.IsSuccessStatusCode)
+                {
+                    await LoadAccountsFromApi();
+                    CloseModal(); 
+                }
+                else
+                {
+                    errorMessage = $"Failed to add account. {response.ReasonPhrase}";
+                }
             }
         }
-        else
+        catch (Exception ex)
         {
-            // Add new account locally
-            if (accounts.Any(a => a.AccountCode == selectedAccount.AccountCode))
-            {
-                errorMessage = "An account with this Account Code already exists.";
-                return;
-            }
-
-            accounts.Add(new AccountViewModel
-            {
-                AccountCode = selectedAccount.AccountCode,
-                AccountName = selectedAccount.AccountName,
-                TotalBalance = selectedAccount.TotalBalance,
-                TotalDebitBalance = selectedAccount.TotalDebitBalance,
-                TotalCreditBalance = selectedAccount.TotalCreditBalance,
-                ChildAccounts = new List<AccountViewModel>()
-            });
+            errorMessage = $"An error occurred: {ex.Message}";
         }
 
         CloseModal();
     }
 
     // Delete Account
-    private void ConfirmDeleteAccount()
+    private async Task ConfirmDeleteAccount()
     {
         if (selectedAccount == null)
         {
@@ -352,8 +365,28 @@ else
             return;
         }
 
-        accounts.Remove(selectedAccount);
-        CloseDeleteModal();
+        try
+        {
+            string? apiUrl = Configuration["ApiUrl"];
+            var client = ClientFactory.CreateClient();
+
+            var response = await client.DeleteAsync($"{apiUrl}financials/deleteaccount/{selectedAccount.AccountCode}");
+
+            if (response.IsSuccessStatusCode)
+            {
+                accounts.Remove(selectedAccount);
+                selectedAccount = null;
+                CloseDeleteModal();
+            }
+            else
+            {
+                errorMessage = $"Failed to delete account. Status: {response.StatusCode}";
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Error: {ex.Message}";
+        }
     }
 
     // ViewModel for Accounts
@@ -364,6 +397,13 @@ else
         public decimal TotalBalance { get; set; }
         public decimal TotalDebitBalance { get; set; }
         public decimal TotalCreditBalance { get; set; }
+        public int AccountClassId { get; set; }
+        public int CompanyId { get; set; }
+        public int? ParentAccountId { get; set; }
+        public string? Description { get; set; }
+        public bool IsCash { get; set; }
+        public bool IsContraAccount { get; set; }
+
         public List<AccountViewModel> ChildAccounts { get; set; } = new();
     }
 }

--- a/src/Api/Controllers/FinancialsController.cs
+++ b/src/Api/Controllers/FinancialsController.cs
@@ -390,14 +390,33 @@ namespace Api.Controllers
             {
                 AccountCode = newAccountDto.AccountCode,
                 AccountName = newAccountDto.AccountName,
-                // Balance = 0, // Initialize read-only fields
-                // DebitBalance = 0,
-                // CreditBalance = 0
+                AccountClassId = newAccountDto.AccountClassId,
+                ParentAccountId = newAccountDto.ParentAccountId,
+                CompanyId = newAccountDto.CompanyId,
+                Description = newAccountDto.Description,
+                IsCash = newAccountDto.IsCash,
+                IsContraAccount = newAccountDto.IsContraAccount
             };
 
             var createdAccount = await _accountService.AddAccountAsync(newAccount);
 
-            return CreatedAtAction(nameof(GetAccountByCode), new { accountCode = createdAccount.AccountCode }, createdAccount);
+            var resultDto = new Dto.Financial.Account
+            {
+                Id = createdAccount.Id,
+                AccountCode = createdAccount.AccountCode,
+                AccountName = createdAccount.AccountName,
+                AccountClassId = createdAccount.AccountClassId,
+                ParentAccountId = createdAccount.ParentAccountId,
+                CompanyId = createdAccount.CompanyId,
+                Description = createdAccount.Description,
+                IsCash = createdAccount.IsCash,
+                IsContraAccount = createdAccount.IsContraAccount,
+                Balance = 0,
+                DebitBalance = 0,
+                CreditBalance = 0
+            };
+
+            return Ok(resultDto);
         }
 
         [HttpPut]
@@ -407,31 +426,63 @@ namespace Api.Controllers
             if (!ModelState.IsValid)
                 return BadRequest(ModelState);
 
-            var updatedAccount = await _accountService.UpdateAccountAsync(accountCode, new Core.Domain.Financials.Account
+            var updated = await _accountService.UpdateAccountAsync(accountCode, new Core.Domain.Financials.Account
             {
                 AccountCode = updatedAccountDto.AccountCode,
                 AccountName = updatedAccountDto.AccountName,
-                // Balance = updatedAccountDto.Balance,
-                // DebitBalance = updatedAccountDto.DebitBalance,
-                // CreditBalance = updatedAccountDto.CreditBalance
             });
-            if (updatedAccount == null)
+
+            if (updated == null)
                 return NotFound();
 
-            return Ok(updatedAccount);
+            // return simplified DTO to avoid Balance-related null issues
+            var resultDto = new Dto.Financial.Account
+            {
+                Id = updated.Id,
+                AccountCode = updated.AccountCode,
+                AccountName = updated.AccountName,
+                AccountClassId = updated.AccountClassId,
+                ParentAccountId = updated.ParentAccountId,
+                CompanyId = updated.CompanyId,
+                Description = updated.Description,
+                IsCash = updated.IsCash,
+                IsContraAccount = updated.IsContraAccount,
+                Balance = 0,
+                DebitBalance = 0,
+                CreditBalance = 0
+            };
+
+            return Ok(resultDto);
         }
+
 
         [HttpDelete]
         [Route("DeleteAccount/{accountCode}")]
         public async Task<IActionResult> DeleteAccount(string accountCode)
         {
             var result = await _accountService.DeleteAccountAsync(accountCode);
-
             if (result == null)
                 return NotFound();
 
-            return Ok(result);
+            var resultDto = new Dto.Financial.Account
+            {
+                Id = result.Id,
+                AccountCode = result.AccountCode,
+                AccountName = result.AccountName,
+                AccountClassId = result.AccountClassId,
+                ParentAccountId = result.ParentAccountId,
+                CompanyId = result.CompanyId,
+                Description = result.Description,
+                IsCash = result.IsCash,
+                IsContraAccount = result.IsContraAccount,
+                Balance = 0,
+                DebitBalance = 0,
+                CreditBalance = 0
+            };
+
+            return Ok(resultDto);
         }
+
 
         #endregion
 

--- a/src/Api/Data/ChartOfAccounts.csv
+++ b/src/Api/Data/ChartOfAccounts.csv
@@ -58,6 +58,7 @@ AccountCode,AccountName,ParentAccountCode,AccountClass,ContraAccount,Cash,Compan
 40400,Sales Discounts,40000,4,FALSE,FALSE,100,CR
 40500,Shipping and Handling,40000,4,FALSE,FALSE,100,CR
 40600,Other Income,40000,4,FALSE,FALSE,100,CR
+40700,Donations,40000,4,FALSE,FALSE,100,CR
 50000,Expenses,,5,FALSE,FALSE,100,DR
 50100,General and Admin Expenses,50000,5,FALSE,FALSE,100,DR
 50101,Salary Expenses,50100,5,FALSE,FALSE,100,DR

--- a/src/Api/Data/coa.csv
+++ b/src/Api/Data/coa.csv
@@ -58,6 +58,7 @@ AccountCode,AccountName,ParentAccountCode,AccountClass,ContraAccount,Cash,Compan
 40400,Sales Discounts,40000,4,FALSE,FALSE,100,CR
 40500,Shipping and Handling,40000,4,FALSE,FALSE,100,CR
 40600,Other Income,40000,4,FALSE,FALSE,100,CR
+40700,Donations,40000,4,FALSE,FALSE,100,CR
 50000,Expenses,,5,FALSE,FALSE,100,DR
 50100,General and Admin Expenses,50000,5,FALSE,FALSE,100,DR
 50101,Salary Expenses,50100,5,FALSE,FALSE,100,DR


### PR DESCRIPTION
Previously, the Chart of Accounts page only updated the local UI state when adding,
editing, or deleting accounts. The changes were not persisted to the backend.

This update connects the add, edit, and delete operations to the API endpoints,
allowing changes to be stored in the database.
Changes include:
- POST request to /financials/addaccount
- PUT request to /financials/updateaccount/{code}
- DELETE request to /financials/deleteaccount/{code}