### PR TITLE
Add Advances (10114) account to Chart of Accounts

### DIFF
--- a/src/Api/Data/ChartOfAccounts.csv
+++ b/src/Api/Data/ChartOfAccounts.csv
@@ -5,6 +5,7 @@ AccountCode,AccountName,ParentAccountCode,AccountClass,ContraAccount,Cash,Compan
 10111,Regular Checking Account,10110,1,FALSE,FALSE,100,DR
 10112,Savings Account,10110,1,FALSE,FALSE,100,DR
 10113,Cash in Hand A/C,10110,1,FALSE,FALSE,100,DR
+10114,Advances,10100,1,FALSE,FALSE,100,DR
 10120,Accounts Receivable,10100,1,FALSE,FALSE,100,DR
 10130,Other Receivables,10100,1,FALSE,FALSE,100,DR
 10121,Allowance for Doubtful Accounts,10100,1,TRUE,FALSE,100,CR
@@ -88,3 +89,4 @@ AccountCode,AccountName,ParentAccountCode,AccountClass,ContraAccount,Cash,Compan
 50600,Other Expenses,50000,5,FALSE,FALSE,100,DR
 50700,Purchase Tax,50000,5,FALSE,FALSE,100,DR
 99999,Income Summary,NULL,6,FALSE,FALSE,100,NA
+

--- a/src/Api/Data/coa.csv
+++ b/src/Api/Data/coa.csv
@@ -5,6 +5,7 @@ AccountCode,AccountName,ParentAccountCode,AccountClass,ContraAccount,Cash,Compan
 10111,Regular Checking Account,10110,1,FALSE,FALSE,100,DR
 10112,Savings Account,10110,1,FALSE,FALSE,100,DR
 10113,Cash in Hand A/C,10110,1,FALSE,FALSE,100,DR
+10114,Advances,10100,1,FALSE,FALSE,100,DR
 10120,Accounts Receivable,10100,1,FALSE,FALSE,100,DR
 10130,Other Receivables,10100,1,FALSE,FALSE,100,DR
 10121,Allowance for Doubtful Accounts,10100,1,TRUE,FALSE,100,CR


### PR DESCRIPTION
- Added a new account "Advances" under the Chart of Accounts with the following details:
  - AccountCode: 10114
  - AccountName: Advances
  - ParentAccountCode: 10100 (Current Assets)
  - AccountClass: 1 (Assets)
  - Sign: DR
- This change was made as per the requirement to include advance payments made by the organization.
- Updated both `ChartOfAccounts.csv` and `coa.csv` for consistency.

Please review and let me know if any changes are needed!
![스크린샷 2025-04-04 121330](https://github.com/user-attachments/assets/04725148-3062-42b6-a33c-b25a61a469ba)
