### PR TITLE
#96 Modified href route to go to proper Quotation page route

### DIFF
--- a/src/AccountGoWeb/Views/Quotations/Quotations.cshtml
+++ b/src/AccountGoWeb/Views/Quotations/Quotations.cshtml
@@ -43,7 +43,7 @@
         var selectedRows = gridOptions.api.getSelectedRows();
         selectedRow = selectedRows[0];
 
-        document.getElementById('linkViewQuotation').setAttribute('href', 'Quotation?id=' + selectedRow.id);
+        document.getElementById('linkViewQuotation').setAttribute('href', '/Quotations/Quotation?id=' + selectedRow.id);
         document.getElementById('linkViewQuotation').setAttribute('class', 'btn');
 
         if(selectedRow.status == 3)


### PR DESCRIPTION
Quotations page's href route was incorrect, did not go to the proper routing of Controller/Action/id. This has now been fixed and the single Quotation details page can be accessed via the view button.