### PR TITLE
98 payment term not selected

### DIFF
--- a/src/AccountGoWeb/Controllers/QuotationsController.cs
+++ b/src/AccountGoWeb/Controllers/QuotationsController.cs
@@ -65,6 +65,11 @@ namespace AccountGoWeb.Controllers
         [HttpPost]
         public async Task<IActionResult> AddSalesQuotation(Dto.Sales.SalesQuotation model, string? addRowBtn)
         {
+
+            ViewBag.Customers = Models.SelectListItemHelper.Customers();
+                ViewBag.Items = Models.SelectListItemHelper.Items();
+                ViewBag.PaymentTerms = Models.SelectListItemHelper.PaymentTerms();
+                ViewBag.Measurements = Models.SelectListItemHelper.Measurements();
             if (!string.IsNullOrEmpty(addRowBtn))
             {
                 _logger.LogInformation("Add Row Button Clicked");
@@ -76,10 +81,6 @@ namespace AccountGoWeb.Controllers
                     ItemId = 1,
                     MeasurementId = 1,
                 });
-                ViewBag.Customers = Models.SelectListItemHelper.Customers();
-                ViewBag.Items = Models.SelectListItemHelper.Items();
-                ViewBag.PaymentTerms = Models.SelectListItemHelper.PaymentTerms();
-                ViewBag.Measurements = Models.SelectListItemHelper.Measurements();
 
                 return View(model);
 
@@ -98,14 +99,15 @@ namespace AccountGoWeb.Controllers
 
                     if (response.IsSuccessStatusCode) {
                         _logger.LogInformation("Quotation has been successfully saved.");
+                        return RedirectToAction("quotations");
                     } else {
                         _logger.LogInformation("Quotation save failed.");
+                        return View(model);
                     }
-                    return RedirectToAction("quotations");
                 }
             } else {
                 _logger.LogInformation("Model State is not valid.");
-                return RedirectToAction("quotations");
+                return View(model);
             }
             
         }

--- a/src/Dto/Sales/SalesQuotation.cs
+++ b/src/Dto/Sales/SalesQuotation.cs
@@ -1,14 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Dto.Sales
 {
     public class SalesQuotation : BaseDto
     {
         public string? No { get; set; }
+        [Required (ErrorMessage = "Customer is required.")]
         public int? CustomerId { get; set; }
         public string? CustomerName { get; set; }
         public DateTime QuotationDate { get; set; }
+        [Required (ErrorMessage = "Payment Term is required.")]
         public int? PaymentTermId { get; set; }
         public string? ReferenceNo { get; set; }
         public decimal Amount { get { return GetTotalAmount(); } }


### PR DESCRIPTION
I modified the model validation so that you must select a customer and a payment term before creating a sales quotation.
<img width="503" alt="image" src="https://github.com/user-attachments/assets/1256a75d-6fd7-4f73-bfa6-d1337960051e" />

I also modified the page redirection logic to stay on the same page when an invalid sales quotation is submitted.