### PR TITLE
70 Fix Sales Invoice Model

### DIFF
--- a/src/AccountGoWeb/Controllers/SalesController.cs
+++ b/src/AccountGoWeb/Controllers/SalesController.cs
@@ -146,21 +146,21 @@ namespace AccountGoWeb.Controllers
                 ViewBag.TotalAmount = salesInvoiceModel.Amount;
             }
 
-            @ViewBag.Customers = Models.SelectListItemHelper.Customers();
-            @ViewBag.PaymentTerms = Models.SelectListItemHelper.PaymentTerms();
-            @ViewBag.Items = Models.SelectListItemHelper.Items();
-            @ViewBag.Measurements = Models.SelectListItemHelper.Measurements();
+            @ViewBag.Customers = SelectListItemHelper.Customers();
+            @ViewBag.PaymentTerms = SelectListItemHelper.PaymentTerms();
+            @ViewBag.Items = SelectListItemHelper.Items();
+            @ViewBag.Measurements = SelectListItemHelper.Measurements();
 
             return View("SalesInvoice", salesInvoiceModel);
         }
 
-        public async System.Threading.Tasks.Task<IActionResult> SalesInvoices()
+        public async Task<IActionResult> SalesInvoices()
         {
             ViewBag.PageContentHeader = "Sales Invoices";
             using (var client = new HttpClient())
             {
                 var baseUri = _configuration!["ApiUrl"];
-                client.BaseAddress = new System.Uri(baseUri!);
+                client.BaseAddress = new Uri(baseUri!);
                 client.DefaultRequestHeaders.Accept.Clear();
                 var response = await client.GetAsync(baseUri + "sales/salesinvoices");
                 if (response.IsSuccessStatusCode)
@@ -169,10 +169,10 @@ namespace AccountGoWeb.Controllers
                     return View(model: responseJson);
                 }
 
-                @ViewBag.Customers = Models.SelectListItemHelper.Customers();
-                @ViewBag.PaymentTerms = Models.SelectListItemHelper.PaymentTerms();
-                @ViewBag.Items = Models.SelectListItemHelper.Items();
-                @ViewBag.Measurements = Models.SelectListItemHelper.Measurements();
+                @ViewBag.Customers = SelectListItemHelper.Customers();
+                @ViewBag.PaymentTerms = SelectListItemHelper.PaymentTerms();
+                @ViewBag.Items = SelectListItemHelper.Items();
+                @ViewBag.Measurements = SelectListItemHelper.Measurements();
             }
             return View();
         }
@@ -227,7 +227,7 @@ namespace AccountGoWeb.Controllers
         }
 
         [HttpPost]
-        public async System.Threading.Tasks.Task<IActionResult> AddSalesInvoice(SalesInvoice Dto, string? addRowBtn)
+        public async Task<IActionResult> AddSalesInvoice(SalesInvoice Dto, string? addRowBtn)
         {
             if (!string.IsNullOrEmpty(addRowBtn))
             {

--- a/src/AccountGoWeb/Views/Sales/AddSalesInvoice.cshtml
+++ b/src/AccountGoWeb/Views/Sales/AddSalesInvoice.cshtml
@@ -36,8 +36,9 @@
                 <div class="row">
                     <div class="col-sm-3">Posted</div>
                     <div class="col-sm-8">
-                        <input type="hidden" asp-for="Posted" value="false" />
-                        <input class="form-check" asp-for="Posted" type="checkbox" value="true" id="chkPosted" />
+                        <input asp-for="Posted" class="form-check-input" id="chkPosted" />
+                        @* <input type="hidden" name="Posted" value="false" />
+                        <input class="form-check" asp-for="Posted" type="checkbox" value="true" id="chkPosted" /> *@
                         <span asp-validation-for="Posted" class="text-danger"></span>
                     </div>
                 </div>

--- a/src/AccountGoWeb/Views/Sales/Allocate.cshtml
+++ b/src/AccountGoWeb/Views/Sales/Allocate.cshtml
@@ -83,7 +83,7 @@
                                         @Html.HiddenFor(m => Model.AllocationLines[i].InvoiceId)
                                     </td>
                                     <td>
-                                        @Model.AllocationLines[i].Amount
+                                        @Model.AllocationLines[i].Amount?.ToString("F2")
                                     </td>
                                     <td>
                                         @Model.AllocationLines[i].AllocatedAmount

--- a/src/Services/Sales/SalesService.cs
+++ b/src/Services/Sales/SalesService.cs
@@ -732,6 +732,8 @@ namespace Services.Sales
 
         public Result<Dto.Sales.SalesInvoice> CreateSalesInvoice(Dto.Sales.SalesInvoice salesInvoiceDto)
         {
+            _logger.LogInformation("Posted value from SaveSalesInvoice API: " + salesInvoiceDto.Posted); // The Posted value from frontend checkbox
+
             Core.Domain.Sales.SalesOrderHeader? salesOrder = null;
             Core.Domain.Sales.SalesInvoiceHeader? salesInvoice = null;
            
@@ -763,6 +765,18 @@ namespace Services.Sales
             }
 
             _logger.LogInformation("SaveSalesInvoice API " + salesInvoice.CustomerId);
+
+            // Create GeneralLedgerHeader only if posted from api is true
+            if (salesInvoiceDto.Posted)
+            {
+                // Create the GeneralLedgerHeader entry
+                // Use the Service/Financial/FinancialService methods to create GerenearlLedgerHeader
+                // Can be modified as needed
+                var glHeader = _financialService.CreateGeneralLedgerHeader(DocumentTypes.SalesInvoice, salesInvoice.Date, "");
+
+                // Add GeneralLedgerHeader to the SalesInvoice
+                salesInvoice.GeneralLedgerHeader = glHeader;
+            }
 
             SaveSalesInvoice(salesInvoice, salesOrder);
 


### PR DESCRIPTION
The issue where the "Posted" checkbox value wasn’t being saved properly has now been resolved.
The "Posted" state was being determined based on whether the GeneralLedgerHeaderId field in the SalesInvoice entity was null or not from existing logic. Although the checkbox value was selected in the UI, it wasn't being properly tied to the logic that assigns the GeneralLedgerHeaderId, which caused the invoice to remain "unposted" in the backend.
Now when the "Posted" checkbox is selected, it triggers the logic to set the GeneralLedgerHeaderId, making the invoice marked as "Posted" in the system. As a result, these invoices will now appear correctly when selecting Sales Receipts for allocation.
![Picture0](https://github.com/user-attachments/assets/cd5a66fc-93a0-4027-a07f-44a93683caef)
![Picture1](https://github.com/user-attachments/assets/63380020-2310-4654-bdc4-08aa1645abac)
