### PR TITLE
#101 Fixed Errors in routing on quotation edit page

### DIFF
--- a/src/AccountGoWeb/Views/Quotations/Quotation.cshtml
+++ b/src/AccountGoWeb/Views/Quotations/Quotation.cshtml
@@ -11,7 +11,7 @@
 </style>
 
 <div>
-    <a href="#" id="linkEdit" class="btn" onclick="onClickEditButton();">
+    <a id="linkEdit" class="btn" onclick="onClickEditButton();">
         <i class="fa fa-edit"></i>
         Edit
     </a>
@@ -97,7 +97,7 @@
     </div>
     <div class="col-sm-9">
         <input id="btnSave" class="btn btn-sm btn-primary btn-flat pull-left disabledControl" type="submit" value="Save"/>
-        <a href="~/sales/salesinvoices" class="btn btn-sm btn-default btn-flat pull-left">Close</a>
+        <a href="~/Quotations" class="btn btn-sm btn-default btn-flat pull-left">Close</a>
     </div>
 </form>
 

--- a/src/AccountGoWeb/Views/Quotations/Quotations.cshtml
+++ b/src/AccountGoWeb/Views/Quotations/Quotations.cshtml
@@ -43,7 +43,7 @@
         var selectedRows = gridOptions.api.getSelectedRows();
         selectedRow = selectedRows[0];
 
-        document.getElementById('linkViewQuotation').setAttribute('href', 'Quotation?id=' + selectedRow.id);
+        document.getElementById('linkViewQuotation').setAttribute('href', '/Quotations/Quotation?id=' + selectedRow.id);
         document.getElementById('linkViewQuotation').setAttribute('class', 'btn');
 
         if(selectedRow.status == 3)


### PR DESCRIPTION
Removed href of edit button to prevent it from immediately redirecting to the dashboard instead of allowing editing on the Quotation Edit Page.

Changed href of close button on Quotation Edit Page to reroute back to the Quotations List Page instead of to the sales invoice page.