### PR TITLE
Fix the version of SQL Server database image in Aspire

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,3 +19,16 @@ services:
         environment:
             - ASPNETCORE_URLS=http://+:8000
             - APIHOST=api
+    sqlserver:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        container_name: gdb-sql-server
+        environment:
+            - ACCEPT_EULA=Y
+            - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
+        ports:
+            - "1433:1433"
+        volumes:
+            - sqlserver_data:/var/opt/mssql
+
+volumes:
+    sqlserver_data:

--- a/src/MigrationService/MigrationService.csproj
+++ b/src/MigrationService/MigrationService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/src.AppHost/Program.cs
+++ b/src/src.AppHost/Program.cs
@@ -4,7 +4,8 @@ using Google.Protobuf.WellKnownTypes;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlServer = builder.AddSqlServer("gdb-sql-server")
-    .WithImage("mcr.microsoft.com/mssql/server", "2022-latest")
+    .WithImageRegistry("mcr.microsoft.com")
+    .WithImage("mssql/server", "2022-latest")
     .WithEnvironment("ACCEPT_EULA", "Y")
     .WithEnvironment("MSSQL_SA_PASSWORD", "YourStrong!Passw0rd")
     .AddDatabase("gdb-db");
@@ -12,11 +13,11 @@ var sqlServer = builder.AddSqlServer("gdb-sql-server")
 // read environment variable for connection string
 var apiService = builder.AddProject<Projects.Api>("api")
         .WithReference(sqlServer)
-        .WithHttpEndpoint(port: 8001)
+        .WithHttpEndpoint(port: 8001, name: "api-http")
         .WaitFor(sqlServer);
 
 builder.AddProject<Projects.AccountGoWeb>("mvc")
-        .WithHttpEndpoint(port: 8000)
+        .WithHttpEndpoint(port: 8000, name: "mvc-http")
         .WithReference(apiService)
         .WaitFor(apiService);
 

--- a/src/src.AppHost/Program.cs
+++ b/src/src.AppHost/Program.cs
@@ -4,15 +4,10 @@ using Google.Protobuf.WellKnownTypes;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlServer = builder.AddSqlServer("gdb-sql-server")
-                 .AddDatabase("gdb-db");
-
-/*
-var sqlServer = builder.AddSqlServer("gdb-sql-server")
-    .WithImage("mcr.microsoft.com/azure-sql-edge", "latest")
+    .WithImage("mcr.microsoft.com/mssql/server", "2022-latest")
     .WithEnvironment("ACCEPT_EULA", "Y")
     .WithEnvironment("MSSQL_SA_PASSWORD", "YourStrong!Passw0rd")
     .AddDatabase("gdb-db");
-*/
 
 // read environment variable for connection string
 var apiService = builder.AddProject<Projects.Api>("api")

--- a/src/src.AppHost/Program.cs
+++ b/src/src.AppHost/Program.cs
@@ -4,11 +4,14 @@ using Google.Protobuf.WellKnownTypes;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlServer = builder.AddSqlServer("gdb-sql-server")
-    .WithImageRegistry("mcr.microsoft.com")
-    .WithImage("mssql/server", "2022-latest")
-    .WithEnvironment("ACCEPT_EULA", "Y")
-    .WithEnvironment("MSSQL_SA_PASSWORD", "YourStrong!Passw0rd")
-    .AddDatabase("gdb-db");
+                 .AddDatabase("gdb-db");
+
+// var sqlServer = builder.AddSqlServer("gdb-sql-server")
+//     .WithImageRegistry("mcr.microsoft.com")
+//     .WithImage("mssql/server", "2022-latest")
+//     .WithEnvironment("ACCEPT_EULA", "Y")
+//     .WithEnvironment("MSSQL_SA_PASSWORD", "YourStrong!Passw0rd")
+//     .AddDatabase("gdb-db");
 
 // read environment variable for connection string
 var apiService = builder.AddProject<Projects.Api>("api")

--- a/src/src.AppHost/appsettings.Development.json
+++ b/src/src.AppHost/appsettings.Development.json
@@ -4,8 +4,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "AppHost": {
-    "AllowUnsecuredTransport": true
   }
 }

--- a/src/src.AppHost/appsettings.Development.json
+++ b/src/src.AppHost/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AppHost": {
+    "AllowUnsecuredTransport": true
   }
 }

--- a/src/src.AppHost/src.AppHost.csproj
+++ b/src/src.AppHost/src.AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.0.1" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.1.0" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="9.1.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/GoodBooks.BackendTests/GoodBooks.BackendTests.csproj
+++ b/test/GoodBooks.BackendTests/GoodBooks.BackendTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Bug:
Aspire 9.1.0 + .NET 10.0 preview bug preventing container creation via dashboard, but verified SQL Server 2022 runs successfully via docker-compose and manual Docker commands.