### PR TITLE
Customer form: invoicing, payment terms, addresses

### DIFF
--- a/src/AccountGoWeb/Components/Pages/Quotations/AddSalesQuotation.razor
+++ b/src/AccountGoWeb/Components/Pages/Quotations/AddSalesQuotation.razor
@@ -37,7 +37,7 @@
                             <option value=""></option>
                             <option value="1">Payment due within 10 days</option>
                             <option value="2">Due 15th Of the Following Month &#x9;</option>
-                            <option value="3">Cash Only</option>
+                            <option value="3">E-Transfer</option>
                         </select>
                         <ValidationMessage For="@(() => model.PaymentTermId)" />
                     </div>

--- a/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
@@ -209,7 +209,12 @@
                                     <label class="form-label">Province</label>
                                 </div>
                                 <div class="col-sm-8">
-                                    <InputText class="form-control" @bind-Value="Model.Province" placeholder="Province ..." disabled="@(!isEditMode)" />
+                                    <InputSelect class="form-control" @bind-Value="Model.Province" disabled="@(!isEditMode)">
+                                        @foreach (var p in CanadianProvinces)
+                                        {
+                                            <option value="@p.Value">@p.Text</option>
+                                        }
+                                    </InputSelect>
                                 </div>
                             </div>
                             <div class="row mb-3">
@@ -237,65 +242,82 @@
             <div class="card mb-3">
                 <div class="card-header" style="background-color: #3a3f44; color: white;">
                     <i class="fa fa-truck"></i> Shipping Address
-                    <button type="button" class="btn btn-sm btn-secondary float-end" @onclick="CopyCustomerToShippingAddress" disabled="@(!isEditMode)">
-                        Copy from Customer Address
-                    </button>
                 </div>
                 <div class="card-body" style="background-color: #2b2f33;">
-                    <div class="row">
-                        <div class="col-sm-6">
-                            <div class="row mb-3">
-                                <div class="col-sm-4">
-                                    <label class="form-label">Street Line 1</label>
-                                </div>
-                                <div class="col-sm-8">
-                                    <InputText class="form-control" @bind-Value="Model.ShippingAddressLine1" placeholder="Street Line 1 ..." disabled="@(!isEditMode)" />
-                                </div>
-                            </div>
-                            <div class="row mb-3">
-                                <div class="col-sm-4">
-                                    <label class="form-label">Street Line 2</label>
-                                </div>
-                                <div class="col-sm-8">
-                                    <InputText class="form-control" @bind-Value="Model.ShippingAddressLine2" placeholder="Street Line 2 ..." disabled="@(!isEditMode)" />
-                                </div>
-                            </div>
-                            <div class="row mb-3">
-                                <div class="col-sm-4">
-                                    <label class="form-label">City</label>
-                                </div>
-                                <div class="col-sm-8">
-                                    <InputText class="form-control" @bind-Value="Model.ShippingCity" placeholder="City ..." disabled="@(!isEditMode)" />
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-6">
-                            <div class="row mb-3">
-                                <div class="col-sm-4">
-                                    <label class="form-label">Province</label>
-                                </div>
-                                <div class="col-sm-8">
-                                    <InputText class="form-control" @bind-Value="Model.ShippingProvince" placeholder="Province ..." disabled="@(!isEditMode)" />
-                                </div>
-                            </div>
-                            <div class="row mb-3">
-                                <div class="col-sm-4">
-                                    <label class="form-label">Postal Code</label>
-                                </div>
-                                <div class="col-sm-8">
-                                    <InputText class="form-control" @bind-Value="Model.ShippingPostalCode" placeholder="Postal Code ..." disabled="@(!isEditMode)" />
-                                </div>
-                            </div>
-                            <div class="row mb-3">
-                                <div class="col-sm-4">
-                                    <label class="form-label">Country</label>
-                                </div>
-                                <div class="col-sm-8">
-                                    <InputText class="form-control" @bind-Value="Model.ShippingCountry" placeholder="Country ..." disabled="@(!isEditMode)" />
-                                </div>
+                    <div class="row mb-3">
+                        <div class="col-12">
+                            <div class="form-check">
+                                <InputCheckbox class="form-check-input" id="useMailingForShipping" @bind-Value="useMailingAddressForShipping" disabled="@(!isEditMode)" @onchange="OnUseMailingForShippingChanged" />
+                                <label class="form-check-label form-label" for="useMailingForShipping">Use mailing address for shipping</label>
                             </div>
                         </div>
                     </div>
+                    @if (!useMailingAddressForShipping)
+                    {
+                        <div class="row">
+                            <div class="col-sm-6">
+                                <div class="row mb-3">
+                                    <div class="col-sm-4">
+                                        <label class="form-label">Street Line 1</label>
+                                    </div>
+                                    <div class="col-sm-8">
+                                        <InputText class="form-control" @bind-Value="Model.ShippingAddressLine1" placeholder="Street Line 1 ..." disabled="@(!isEditMode)" />
+                                    </div>
+                                </div>
+                                <div class="row mb-3">
+                                    <div class="col-sm-4">
+                                        <label class="form-label">Street Line 2</label>
+                                    </div>
+                                    <div class="col-sm-8">
+                                        <InputText class="form-control" @bind-Value="Model.ShippingAddressLine2" placeholder="Street Line 2 ..." disabled="@(!isEditMode)" />
+                                    </div>
+                                </div>
+                                <div class="row mb-3">
+                                    <div class="col-sm-4">
+                                        <label class="form-label">City</label>
+                                    </div>
+                                    <div class="col-sm-8">
+                                        <InputText class="form-control" @bind-Value="Model.ShippingCity" placeholder="City ..." disabled="@(!isEditMode)" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-sm-6">
+                                <div class="row mb-3">
+                                    <div class="col-sm-4">
+                                        <label class="form-label">Province</label>
+                                    </div>
+                                    <div class="col-sm-8">
+                                        <InputSelect class="form-control" @bind-Value="Model.ShippingProvince" disabled="@(!isEditMode)">
+                                            @foreach (var p in CanadianProvinces)
+                                            {
+                                                <option value="@p.Value">@p.Text</option>
+                                            }
+                                        </InputSelect>
+                                    </div>
+                                </div>
+                                <div class="row mb-3">
+                                    <div class="col-sm-4">
+                                        <label class="form-label">Postal Code</label>
+                                    </div>
+                                    <div class="col-sm-8">
+                                        <InputText class="form-control" @bind-Value="Model.ShippingPostalCode" placeholder="Postal Code ..." disabled="@(!isEditMode)" />
+                                    </div>
+                                </div>
+                                <div class="row mb-3">
+                                    <div class="col-sm-4">
+                                        <label class="form-label">Country</label>
+                                    </div>
+                                    <div class="col-sm-8">
+                                        <InputText class="form-control" @bind-Value="Model.ShippingCountry" placeholder="Country ..." disabled="@(!isEditMode)" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <p class="text-muted mb-0">Shipping address is the same as the customer address above.</p>
+                    }
                 </div>
             </div>
 
@@ -320,7 +342,7 @@
                                     <label class="form-label">Discount (%)</label>
                                 </div>
                                 <div class="col-sm-8">
-                                    <InputNumber class="form-control" @bind-Value="Model.DiscountPercentage" disabled="@(!isEditMode)" step="0.01" placeholder="0" />
+                                    <InputNumber class="form-control" @bind-Value="Model.DiscountPercentage" disabled="@(!isEditMode)" step="0.01" min="0" max="100" placeholder="0" />
                                 </div>
                             </div>
                         </div>
@@ -394,9 +416,28 @@
 
     private CustomerDto Model { get; set; } = new();
     
-    private List<SelectListItem> Accounts { get; set; } = new();
     private List<SelectListItem> TaxGroups { get; set; } = new();
     private List<SelectListItem> PaymentTerms { get; set; } = new();
+    
+    private bool useMailingAddressForShipping = true;
+    
+    private static readonly List<SelectListItem> CanadianProvinces = new()
+    {
+        new() { Value = "", Text = "-- Select Province --" },
+        new() { Value = "AB", Text = "Alberta" },
+        new() { Value = "BC", Text = "British Columbia" },
+        new() { Value = "MB", Text = "Manitoba" },
+        new() { Value = "NB", Text = "New Brunswick" },
+        new() { Value = "NL", Text = "Newfoundland and Labrador" },
+        new() { Value = "NS", Text = "Nova Scotia" },
+        new() { Value = "NT", Text = "Northwest Territories" },
+        new() { Value = "NU", Text = "Nunavut" },
+        new() { Value = "ON", Text = "Ontario" },
+        new() { Value = "PE", Text = "Prince Edward Island" },
+        new() { Value = "QC", Text = "Quebec" },
+        new() { Value = "SK", Text = "Saskatchewan" },
+        new() { Value = "YT", Text = "Yukon" }
+    };
     
     private bool isLoading = true;
     private bool isEditMode = false;
@@ -465,6 +506,7 @@
             if (response.IsSuccessStatusCode)
             {
                 Model = await response.Content.ReadFromJsonAsync<CustomerDto>() ?? new();
+                useMailingAddressForShipping = ShippingEqualsMailing();
             }
             else
             {
@@ -483,14 +525,6 @@
         {
             string baseApiUrl = Environment.GetEnvironmentVariable("APIURL") ?? "http://localhost:8001/api/";
             
-            // Load accounts
-            var accountsResponse = await Http.GetAsync(baseApiUrl + "common/postingaccounts");
-            if (accountsResponse.IsSuccessStatusCode)
-            {
-                var accounts = await accountsResponse.Content.ReadFromJsonAsync<List<Dto.Financial.Account>>();
-                Accounts = accounts?.Select(a => new SelectListItem { Value = a.Id.ToString(), Text = a.AccountName! }).ToList() ?? new();
-            }
-
             // Load tax groups
             var taxGroupsResponse = await Http.GetAsync(baseApiUrl + "tax/taxgroups");
             if (taxGroupsResponse.IsSuccessStatusCode)
@@ -517,6 +551,16 @@
     {
         try
         {
+            if (useMailingAddressForShipping)
+            {
+                Model.ShippingAddressLine1 = Model.AddressLine1;
+                Model.ShippingAddressLine2 = Model.AddressLine2;
+                Model.ShippingCity = Model.City;
+                Model.ShippingProvince = Model.Province;
+                Model.ShippingPostalCode = Model.PostalCode;
+                Model.ShippingCountry = Model.Country;
+            }
+            
             string baseApiUrl = Environment.GetEnvironmentVariable("APIURL") ?? "http://localhost:8001/api/";
             var apiUrl = baseApiUrl + "sales/savecustomer";
             
@@ -558,14 +602,28 @@
         Navigation.NavigateTo($"/contact/contacts?partyId={Model.Id}&partyType=1", forceLoad: true);
     }
 
-    private void CopyCustomerToShippingAddress()
+    private bool ShippingEqualsMailing()
     {
-        Model.ShippingAddressLine1 = Model.AddressLine1;
-        Model.ShippingAddressLine2 = Model.AddressLine2;
-        Model.ShippingCity = Model.City;
-        Model.ShippingProvince = Model.Province;
-        Model.ShippingPostalCode = Model.PostalCode;
-        Model.ShippingCountry = Model.Country;
+        return string.Equals(Model.AddressLine1 ?? "", Model.ShippingAddressLine1 ?? "", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(Model.AddressLine2 ?? "", Model.ShippingAddressLine2 ?? "", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(Model.City ?? "", Model.ShippingCity ?? "", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(Model.Province ?? "", Model.ShippingProvince ?? "", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(Model.PostalCode ?? "", Model.ShippingPostalCode ?? "", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(Model.Country ?? "", Model.ShippingCountry ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void OnUseMailingForShippingChanged(ChangeEventArgs e)
+    {
+        var useMailing = e.Value as bool? ?? false;
+        if (!useMailing)
+        {
+            Model.ShippingAddressLine1 = Model.AddressLine1;
+            Model.ShippingAddressLine2 = Model.AddressLine2;
+            Model.ShippingCity = Model.City;
+            Model.ShippingProvince = Model.Province;
+            Model.ShippingPostalCode = Model.PostalCode;
+            Model.ShippingCountry = Model.Country;
+        }
     }
 
     public class SelectListItem

--- a/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
@@ -170,6 +170,135 @@
                 </div>
             </div>
 
+            @* Customer Address Section *@
+            <div class="card mb-3">
+                <div class="card-header" style="background-color: #3a3f44; color: white;">
+                    <i class="fa fa-map-marker"></i> Customer Address
+                </div>
+                <div class="card-body" style="background-color: #2b2f33;">
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Street Line 1</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.AddressLine1" placeholder="Street Line 1 ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Street Line 2</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.AddressLine2" placeholder="Street Line 2 ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">City</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.City" placeholder="City ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6">
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Province</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.Province" placeholder="Province ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Postal Code</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.PostalCode" placeholder="Postal Code ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Country</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.Country" placeholder="Country ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            @* Shipping Address Section *@
+            <div class="card mb-3">
+                <div class="card-header" style="background-color: #3a3f44; color: white;">
+                    <i class="fa fa-truck"></i> Shipping Address
+                    <button type="button" class="btn btn-sm btn-secondary float-end" @onclick="CopyCustomerToShippingAddress" disabled="@(!isEditMode)">
+                        Copy from Customer Address
+                    </button>
+                </div>
+                <div class="card-body" style="background-color: #2b2f33;">
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Street Line 1</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.ShippingAddressLine1" placeholder="Street Line 1 ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Street Line 2</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.ShippingAddressLine2" placeholder="Street Line 2 ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">City</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.ShippingCity" placeholder="City ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6">
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Province</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.ShippingProvince" placeholder="Province ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Postal Code</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.ShippingPostalCode" placeholder="Postal Code ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                            <div class="row mb-3">
+                                <div class="col-sm-4">
+                                    <label class="form-label">Country</label>
+                                </div>
+                                <div class="col-sm-8">
+                                    <InputText class="form-control" @bind-Value="Model.ShippingCountry" placeholder="Country ..." disabled="@(!isEditMode)" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             @* Invoicing Section *@
             <div class="card mb-3">
                 <div class="card-header" style="background-color: #3a3f44; color: white;">
@@ -427,6 +556,16 @@
     private void NavigateToContacts()
     {
         Navigation.NavigateTo($"/contact/contacts?partyId={Model.Id}&partyType=1", forceLoad: true);
+    }
+
+    private void CopyCustomerToShippingAddress()
+    {
+        Model.ShippingAddressLine1 = Model.AddressLine1;
+        Model.ShippingAddressLine2 = Model.AddressLine2;
+        Model.ShippingCity = Model.City;
+        Model.ShippingProvince = Model.Province;
+        Model.ShippingPostalCode = Model.PostalCode;
+        Model.ShippingCountry = Model.Country;
     }
 
     public class SelectListItem

--- a/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
@@ -188,16 +188,10 @@
                             </div>
                             <div class="row mb-3">
                                 <div class="col-sm-4">
-                                    <label class="form-label">Discount</label>
+                                    <label class="form-label">Discount (%)</label>
                                 </div>
                                 <div class="col-sm-8">
-                                    <InputSelect class="form-control" @bind-Value="Model.SalesDiscountAccountId" disabled="@(!isEditMode)">
-                                        <option value="">-- Select Account --</option>
-                                        @foreach (var account in Accounts)
-                                        {
-                                            <option value="@account.Value">@account.Text</option>
-                                        }
-                                    </InputSelect>
+                                    <InputNumber class="form-control" @bind-Value="Model.DiscountPercentage" disabled="@(!isEditMode)" step="0.01" placeholder="0" />
                                 </div>
                             </div>
                         </div>

--- a/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
@@ -183,13 +183,7 @@
                                     <label class="form-label">Accounts Receivable</label>
                                 </div>
                                 <div class="col-sm-8">
-                                    <InputSelect class="form-control" @bind-Value="Model.AccountsReceivableId" disabled="@(!isEditMode)">
-                                        <option value="">-- Select Account --</option>
-                                        @foreach (var account in Accounts)
-                                        {
-                                            <option value="@account.Value">@account.Text</option>
-                                        }
-                                    </InputSelect>
+                                    <input type="text" class="form-control" value="10120 - Accounts Receivable" readonly />
                                 </div>
                             </div>
                             <div class="row mb-3">

--- a/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/Customer.razor
@@ -188,34 +188,6 @@
                             </div>
                             <div class="row mb-3">
                                 <div class="col-sm-4">
-                                    <label class="form-label">Sales</label>
-                                </div>
-                                <div class="col-sm-8">
-                                    <InputSelect class="form-control" @bind-Value="Model.SalesAccountId" disabled="@(!isEditMode)">
-                                        <option value="">-- Select Account --</option>
-                                        @foreach (var account in Accounts)
-                                        {
-                                            <option value="@account.Value">@account.Text</option>
-                                        }
-                                    </InputSelect>
-                                </div>
-                            </div>
-                            <div class="row mb-3">
-                                <div class="col-sm-4">
-                                    <label class="form-label">Prepayment</label>
-                                </div>
-                                <div class="col-sm-8">
-                                    <InputSelect class="form-control" @bind-Value="Model.PrepaymentAccountId" disabled="@(!isEditMode)">
-                                        <option value="">-- Select Account --</option>
-                                        @foreach (var account in Accounts)
-                                        {
-                                            <option value="@account.Value">@account.Text</option>
-                                        }
-                                    </InputSelect>
-                                </div>
-                            </div>
-                            <div class="row mb-3">
-                                <div class="col-sm-4">
                                     <label class="form-label">Discount</label>
                                 </div>
                                 <div class="col-sm-8">

--- a/src/Api/Controllers/SalesController.cs
+++ b/src/Api/Controllers/SalesController.cs
@@ -92,8 +92,6 @@ namespace Api.Controllers
             customer.ShippingCountry = customerDto.ShippingCountry;
             var accountAr = _financialService.GetAccountByAccountCode("10120");
             customer.AccountsReceivableAccountId = accountAr?.Id;
-            customer.SalesAccountId = customerDto.SalesAccountId;
-            customer.CustomerAdvancesAccountId = customerDto.PrepaymentAccountId;
             var accountDiscount = _financialService.GetAccountByAccountCode("40400");
             customer.SalesDiscountAccountId = accountDiscount?.Id;
             customer.DiscountPercentage = customerDto.DiscountPercentage;
@@ -189,7 +187,9 @@ namespace Api.Controllers
                     customerDto.Fax = customer.Party.Fax;
                     customerDto.Balance = customer.Balance;
                     customerDto.PrepaymentAccountId = customer.CustomerAdvancesAccountId;
-                    customerDto.Contact = customer.PrimaryContact.FirstName + " " + customer.PrimaryContact.LastName;
+                    customerDto.Contact = customer.PrimaryContact != null
+                        ? $"{customer.PrimaryContact.FirstName} {customer.PrimaryContact.LastName}".Trim()
+                        : string.Empty;
                     customerDto.TaxGroup = customer.TaxGroup == null ? string.Empty : customer.TaxGroup.Description;
                     customersDto.Add(customerDto);
                 }

--- a/src/Api/Controllers/SalesController.cs
+++ b/src/Api/Controllers/SalesController.cs
@@ -82,7 +82,9 @@ namespace Api.Controllers
             customer.AccountsReceivableAccountId = accountAr?.Id;
             customer.SalesAccountId = customerDto.SalesAccountId;
             customer.CustomerAdvancesAccountId = customerDto.PrepaymentAccountId;
-            customer.SalesDiscountAccountId = customerDto.SalesDiscountAccountId;
+            var accountDiscount = _financialService.GetAccountByAccountCode("40400");
+            customer.SalesDiscountAccountId = accountDiscount?.Id;
+            customer.DiscountPercentage = customerDto.DiscountPercentage;
             customer.PaymentTermId = customerDto.PaymentTermId;
             customer.TaxGroupId = customerDto.TaxGroupId;
             customer.ModifiedBy = GetUserNameFromRequestHeader();
@@ -111,6 +113,7 @@ namespace Api.Controllers
                     SalesAccountId = customer.SalesAccountId.GetValueOrDefault(),
                     PrepaymentAccountId = customer.CustomerAdvancesAccountId.GetValueOrDefault(),
                     SalesDiscountAccountId = customer.SalesDiscountAccountId.GetValueOrDefault(),
+                    DiscountPercentage = customer.DiscountPercentage,
                     PaymentTermId = customer.PaymentTermId.GetValueOrDefault(),
                     TaxGroupId = customer.TaxGroupId.GetValueOrDefault()
                 };

--- a/src/Api/Controllers/SalesController.cs
+++ b/src/Api/Controllers/SalesController.cs
@@ -1,4 +1,4 @@
-﻿using Api.ActionFilters;
+using Api.ActionFilters;
 using Core.Domain;
 using Dto.Sales;
 using Microsoft.AspNetCore.Mvc;
@@ -78,7 +78,8 @@ namespace Api.Controllers
             customer.PrimaryContact.Party.Email = customerDto.PrimaryContact.Party.Email;
             customer.PrimaryContact.Party.Fax = customerDto.PrimaryContact.Party.Fax;
             customer.PrimaryContact.Party.Website = customerDto.PrimaryContact.Party.Website;
-            customer.AccountsReceivableAccountId = customerDto.AccountsReceivableId;
+            var accountAr = _financialService.GetAccountByAccountCode("10120");
+            customer.AccountsReceivableAccountId = accountAr?.Id;
             customer.SalesAccountId = customerDto.SalesAccountId;
             customer.CustomerAdvancesAccountId = customerDto.PrepaymentAccountId;
             customer.SalesDiscountAccountId = customerDto.SalesDiscountAccountId;

--- a/src/Api/Controllers/SalesController.cs
+++ b/src/Api/Controllers/SalesController.cs
@@ -78,6 +78,18 @@ namespace Api.Controllers
             customer.PrimaryContact.Party.Email = customerDto.PrimaryContact.Party.Email;
             customer.PrimaryContact.Party.Fax = customerDto.PrimaryContact.Party.Fax;
             customer.PrimaryContact.Party.Website = customerDto.PrimaryContact.Party.Website;
+            customer.AddressLine1 = customerDto.AddressLine1;
+            customer.AddressLine2 = customerDto.AddressLine2;
+            customer.City = customerDto.City;
+            customer.Province = customerDto.Province;
+            customer.PostalCode = customerDto.PostalCode;
+            customer.Country = customerDto.Country;
+            customer.ShippingAddressLine1 = customerDto.ShippingAddressLine1;
+            customer.ShippingAddressLine2 = customerDto.ShippingAddressLine2;
+            customer.ShippingCity = customerDto.ShippingCity;
+            customer.ShippingProvince = customerDto.ShippingProvince;
+            customer.ShippingPostalCode = customerDto.ShippingPostalCode;
+            customer.ShippingCountry = customerDto.ShippingCountry;
             var accountAr = _financialService.GetAccountByAccountCode("10120");
             customer.AccountsReceivableAccountId = accountAr?.Id;
             customer.SalesAccountId = customerDto.SalesAccountId;
@@ -122,6 +134,18 @@ namespace Api.Controllers
                 customerDto.Website = customer.Party.Website;
                 customerDto.Phone = customer.Party.Phone;
                 customerDto.Fax = customer.Party.Fax;
+                customerDto.AddressLine1 = customer.AddressLine1;
+                customerDto.AddressLine2 = customer.AddressLine2;
+                customerDto.City = customer.City;
+                customerDto.Province = customer.Province;
+                customerDto.PostalCode = customer.PostalCode;
+                customerDto.Country = customer.Country;
+                customerDto.ShippingAddressLine1 = customer.ShippingAddressLine1;
+                customerDto.ShippingAddressLine2 = customer.ShippingAddressLine2;
+                customerDto.ShippingCity = customer.ShippingCity;
+                customerDto.ShippingProvince = customer.ShippingProvince;
+                customerDto.ShippingPostalCode = customer.ShippingPostalCode;
+                customerDto.ShippingCountry = customer.ShippingCountry;
 
                 if (customer.PrimaryContact != null)
                 {

--- a/src/Api/Data/Initializer.cs
+++ b/src/Api/Data/Initializer.cs
@@ -486,8 +486,8 @@ namespace Api.Data
             });
             paymentTerms.Add(new Core.Domain.PaymentTerm
             {
-                Description = "Cash Only",
-                PaymentType = Core.Domain.PaymentTypes.Cash,
+                Description = "E-Transfer",
+                PaymentType = Core.Domain.PaymentTypes.ETransfer,
                 IsActive = true,
             });
 

--- a/src/Api/Data/Migrations/ApiDb/20260309023800_AddCustomerDiscountPercentage.Designer.cs
+++ b/src/Api/Data/Migrations/ApiDb/20260309023800_AddCustomerDiscountPercentage.Designer.cs
@@ -4,6 +4,7 @@ using Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Api.Data.Migrations.ApiDb
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260309023800_AddCustomerDiscountPercentage")]
+    partial class AddCustomerDiscountPercentage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Api/Data/Migrations/ApiDb/20260309023800_AddCustomerDiscountPercentage.cs
+++ b/src/Api/Data/Migrations/ApiDb/20260309023800_AddCustomerDiscountPercentage.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Data.Migrations.ApiDb
+{
+    /// <inheritdoc />
+    public partial class AddCustomerDiscountPercentage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "DiscountPercentage",
+                table: "Customer",
+                type: "decimal(18,2)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DiscountPercentage",
+                table: "Customer");
+        }
+    }
+}

--- a/src/Api/Data/Migrations/ApiDb/20260309180111_AddCustomerAddressColumns.Designer.cs
+++ b/src/Api/Data/Migrations/ApiDb/20260309180111_AddCustomerAddressColumns.Designer.cs
@@ -4,6 +4,7 @@ using Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Api.Data.Migrations.ApiDb
 {
     [DbContext(typeof(ApiDbContext))]
-    partial class ApiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260309180111_AddCustomerAddressColumns")]
+    partial class AddCustomerAddressColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Api/Data/Migrations/ApiDb/20260309180111_AddCustomerAddressColumns.cs
+++ b/src/Api/Data/Migrations/ApiDb/20260309180111_AddCustomerAddressColumns.cs
@@ -1,0 +1,138 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Data.Migrations.ApiDb
+{
+    /// <inheritdoc />
+    public partial class AddCustomerAddressColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "AddressLine1",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "AddressLine2",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "City",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Country",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "PostalCode",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Province",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingAddressLine1",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingAddressLine2",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingCity",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingCountry",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingPostalCode",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ShippingProvince",
+                table: "Customer",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AddressLine1",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "AddressLine2",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "City",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "Country",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "PostalCode",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "Province",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingAddressLine1",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingAddressLine2",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingCity",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingCountry",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingPostalCode",
+                table: "Customer");
+
+            migrationBuilder.DropColumn(
+                name: "ShippingProvince",
+                table: "Customer");
+        }
+    }
+}

--- a/src/Core/Domain/EnumTypes.cs
+++ b/src/Core/Domain/EnumTypes.cs
@@ -135,6 +135,7 @@ namespace Core.Domain
     {
         Prepaymnet = 1,
         Cash,
+        ETransfer,
         AfterNoOfDays,
         DayInTheFollowingMonth
     }

--- a/src/Core/Domain/EnumTypes.cs
+++ b/src/Core/Domain/EnumTypes.cs
@@ -134,10 +134,10 @@ namespace Core.Domain
     public enum PaymentTypes
     {
         Prepaymnet = 1,
-        Cash,
-        ETransfer,
-        AfterNoOfDays,
-        DayInTheFollowingMonth
+        Cash = 2,
+        AfterNoOfDays = 3,
+        DayInTheFollowingMonth = 4,
+        ETransfer = 5
     }
 
     public enum BankTypes

--- a/src/Core/Domain/Sales/Customer.cs
+++ b/src/Core/Domain/Sales/Customer.cs
@@ -31,6 +31,7 @@ namespace Core.Domain.Sales
         public int? AccountsReceivableAccountId { get; set; }
         public int? SalesAccountId { get; set; }
         public int? SalesDiscountAccountId { get; set; }
+        public decimal? DiscountPercentage { get; set; }
         public int? PromptPaymentDiscountAccountId { get; set; }
         public int? PaymentTermId { get; set; }
         public int? CustomerAdvancesAccountId { get; set; }

--- a/src/Core/Domain/Sales/Customer.cs
+++ b/src/Core/Domain/Sales/Customer.cs
@@ -35,6 +35,18 @@ namespace Core.Domain.Sales
         public int? PromptPaymentDiscountAccountId { get; set; }
         public int? PaymentTermId { get; set; }
         public int? CustomerAdvancesAccountId { get; set; }
+        public string? AddressLine1 { get; set; }
+        public string? AddressLine2 { get; set; }
+        public string? City { get; set; }
+        public string? Province { get; set; }
+        public string? PostalCode { get; set; }
+        public string? Country { get; set; }
+        public string? ShippingAddressLine1 { get; set; }
+        public string? ShippingAddressLine2 { get; set; }
+        public string? ShippingCity { get; set; }
+        public string? ShippingProvince { get; set; }
+        public string? ShippingPostalCode { get; set; }
+        public string? ShippingCountry { get; set; }
 
         public virtual Party Party { get; set; }
         public virtual TaxGroup TaxGroup { get; set; }

--- a/src/Dto/Sales/Customer.cs
+++ b/src/Dto/Sales/Customer.cs
@@ -31,6 +31,7 @@ namespace Dto.Sales
         public int? SalesAccountId { get; set; }
         public int? PrepaymentAccountId { get; set; }
         public int? SalesDiscountAccountId { get; set; }
+        [Range(0, 100, ErrorMessage = "Discount must be between 0 and 100 percent.")]
         public decimal? DiscountPercentage { get; set; }
         public int? TaxGroupId { get; set; }
         public int? PaymentTermId { get; set; }

--- a/src/Dto/Sales/Customer.cs
+++ b/src/Dto/Sales/Customer.cs
@@ -1,4 +1,4 @@
-﻿using Dto.Common;
+using Dto.Common;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
@@ -18,6 +18,7 @@ namespace Dto.Sales
         public int? SalesAccountId { get; set; }
         public int? PrepaymentAccountId { get; set; }
         public int? SalesDiscountAccountId { get; set; }
+        public decimal? DiscountPercentage { get; set; }
         public int? TaxGroupId { get; set; }
         public int? PaymentTermId { get; set; }
         public decimal Balance { get; set; }        

--- a/src/Dto/Sales/Customer.cs
+++ b/src/Dto/Sales/Customer.cs
@@ -14,6 +14,19 @@ namespace Dto.Sales
         public string? Phone { get; set; }
         public string? Fax { get; set; }
 
+        public string? AddressLine1 { get; set; }
+        public string? AddressLine2 { get; set; }
+        public string? City { get; set; }
+        public string? Province { get; set; }
+        public string? PostalCode { get; set; }
+        public string? Country { get; set; }
+        public string? ShippingAddressLine1 { get; set; }
+        public string? ShippingAddressLine2 { get; set; }
+        public string? ShippingCity { get; set; }
+        public string? ShippingProvince { get; set; }
+        public string? ShippingPostalCode { get; set; }
+        public string? ShippingCountry { get; set; }
+
         public int? AccountsReceivableId { get; set; }
         public int? SalesAccountId { get; set; }
         public int? PrepaymentAccountId { get; set; }


### PR DESCRIPTION
**Closes #212**

## Summary

- **Invoicing:** Accounts Receivable fixed to GL 10120 (read-only). Sales and Prepayment removed. Discount is a single percentage field (0–100), GL 40400 set on save.
- **Payment:** “Cash Only” replaced with “E-Transfer” in enum, seed, and quotation form.
- **Addresses:** Customer and shipping address sections added (Street 1/2, City, Province, Postal Code, Country). Province is a Canadian provinces dropdown. “Use mailing address for shipping” checkbox replaces duplicate fields and copy button; when unchecked, shipping fields appear and are pre-filled from mailing.

## Changes

- **Customer.razor:** AR read-only, Sales/Prepayment removed, Discount % with min/max, Customer + Shipping address sections, Canadian province dropdowns, “Use mailing address for shipping” with conditional shipping fields, copy-on-save when checked, unused Accounts loading removed.
- **SalesController:** AR/Discount GL from codes 10120/40400, address and DiscountPercentage mapping, SalesAccountId/PrepaymentAccountId mapping removed, null-safe Contact in Customers list.
- **DTO/Domain:** Address fields, Shipping fields, DiscountPercentage with `[Range(0, 100)]`.
- **EnumTypes:** `ETransfer = 5` added; existing PaymentTypes values unchanged.
- **Initializer / AddSalesQuotation:** E-Transfer label and type.
- **Migrations:** AddCustomerDiscountPercentage, AddCustomerAddressColumns.