### PR TITLE
Fix #197 vendor payment term dropdown

### DIFF
--- a/src/AccountGoWeb/Components/Pages/Purchasing/VendorForm.razor
+++ b/src/AccountGoWeb/Components/Pages/Purchasing/VendorForm.razor
@@ -35,7 +35,7 @@
                         <div class="col-sm-2">Name</div>
                         <div class="col-sm-10">
                             <InputText @bind-Value="vendor.Name" class="form-control" placeholder="Name ..."
-                                disabled="@(!isEditMode)" />
+                                       disabled="@(!isEditMode)" />
                             <ValidationMessage For="@(() => vendor.Name)" />
                         </div>
                     </div>
@@ -45,28 +45,28 @@
                         <div class="col-sm-2">Phone</div>
                         <div class="col-sm-10">
                             <InputText @bind-Value="vendor.Phone" class="form-control" placeholder="Phone ..."
-                                disabled="@(!isEditMode)" />
+                                       disabled="@(!isEditMode)" />
                         </div>
                     </div>
                     <div class="row mb-2">
                         <div class="col-sm-2">Fax</div>
                         <div class="col-sm-10">
                             <InputText @bind-Value="vendor.Fax" class="form-control" placeholder="Fax ..."
-                                disabled="@(!isEditMode)" />
+                                       disabled="@(!isEditMode)" />
                         </div>
                     </div>
                     <div class="row mb-2">
                         <div class="col-sm-2">Website</div>
                         <div class="col-sm-10">
                             <InputText @bind-Value="vendor.Website" class="form-control" placeholder="Website ..."
-                                disabled="@(!isEditMode)" />
+                                       disabled="@(!isEditMode)" />
                         </div>
                     </div>
                     <div class="row mb-2">
                         <div class="col-sm-2">Email</div>
                         <div class="col-sm-10">
                             <InputText @bind-Value="vendor.Email" class="form-control" placeholder="Email ..."
-                                disabled="@(!isEditMode)" />
+                                       disabled="@(!isEditMode)" />
                         </div>
                     </div>
                 </div>
@@ -88,14 +88,14 @@
                         <div class="col-sm-4">First Name</div>
                         <div class="col-sm-8">
                             <InputText @bind-Value="vendor.PrimaryContact.FirstName" class="form-control"
-                                placeholder="First Name ..." disabled="@(!isEditMode)" />
+                                       placeholder="First Name ..." disabled="@(!isEditMode)" />
                         </div>
                     </div>
                     <div class="row mb-2">
                         <div class="col-sm-4">Last Name</div>
                         <div class="col-sm-8">
                             <InputText @bind-Value="vendor.PrimaryContact.LastName" class="form-control"
-                                placeholder="Last Name ..." disabled="@(!isEditMode)" />
+                                       placeholder="Last Name ..." disabled="@(!isEditMode)" />
                         </div>
                     </div>
                 </div>
@@ -104,28 +104,28 @@
                         <div class="col-sm-4">Phone</div>
                         <div class="col-sm-8">
                             <InputText @bind-Value="vendor.PrimaryContact.Party.Phone" class="form-control"
-                                placeholder="Phone ..." disabled="@(!isEditMode)" />
+                                       placeholder="Phone ..." disabled="@(!isEditMode)" />
                         </div>
                     </div>
                     <div class="row mb-2">
                         <div class="col-sm-4">Fax</div>
                         <div class="col-sm-8">
                             <InputText @bind-Value="vendor.PrimaryContact.Party.Fax" class="form-control"
-                                placeholder="Fax ..." disabled="@(!isEditMode)" />
+                                       placeholder="Fax ..." disabled="@(!isEditMode)" />
                         </div>
                     </div>
                     <div class="row mb-2">
                         <div class="col-sm-4">Website</div>
                         <div class="col-sm-8">
                             <InputText @bind-Value="vendor.PrimaryContact.Party.Website" class="form-control"
-                                placeholder="Website ..." disabled="@(!isEditMode)" />
+                                       placeholder="Website ..." disabled="@(!isEditMode)" />
                         </div>
                     </div>
                     <div class="row mb-2">
                         <div class="col-sm-4">Email</div>
                         <div class="col-sm-8">
                             <InputText @bind-Value="vendor.PrimaryContact.Party.Email" class="form-control"
-                                placeholder="Email ..." disabled="@(!isEditMode)" />
+                                       placeholder="Email ..." disabled="@(!isEditMode)" />
                         </div>
                     </div>
                 </div>
@@ -143,7 +143,7 @@
                         <div class="col-sm-6">Accounts Payable</div>
                         <div class="col-sm-6">
                             <InputSelect @bind-Value="vendor.AccountsPayableAccountId" class="form-control"
-                                disabled="@(!isEditMode)">
+                                         disabled="@(!isEditMode)">
                                 <option value="">Select...</option>
                                 @foreach (var account in accounts)
                                 {
@@ -156,7 +156,7 @@
                         <div class="col-sm-6">Purchase</div>
                         <div class="col-sm-6">
                             <InputSelect @bind-Value="vendor.PurchaseAccountId" class="form-control"
-                                disabled="@(!isEditMode)">
+                                         disabled="@(!isEditMode)">
                                 <option value="">Select...</option>
                                 @foreach (var account in accounts)
                                 {
@@ -169,7 +169,7 @@
                         <div class="col-sm-6">Discount</div>
                         <div class="col-sm-6">
                             <InputSelect @bind-Value="vendor.PurchaseDiscountAccountId" class="form-control"
-                                disabled="@(!isEditMode)">
+                                         disabled="@(!isEditMode)">
                                 <option value="">Select...</option>
                                 @foreach (var account in accounts)
                                 {
@@ -207,7 +207,7 @@
                         <div class="col-sm-4">Payment Term</div>
                         <div class="col-sm-8">
                             <InputSelect @bind-Value="vendor.PaymentTermId" class="form-control"
-                                disabled="@(!isEditMode)">
+                                         disabled="@(!isEditMode)">
                                 <option value="">Select...</option>
                                 @foreach (var term in paymentTerms)
                                 {
@@ -325,7 +325,7 @@
             }
 
             // Load payment terms
-            var paymentTermsResponse = await http.GetAsync($"{apiUrl}financial/paymentterms");
+            var paymentTermsResponse = await http.GetAsync($"{apiUrl}common/paymentterms");
             if (paymentTermsResponse.IsSuccessStatusCode)
             {
                 var paymentTermsList = await paymentTermsResponse.Content.ReadFromJsonAsync<List<PaymentTerm>>() ?? new();


### PR DESCRIPTION
Fixes #197

Updated the Vendor form to load payment terms from the correct API endpoint.
The Payment Term dropdown in Accounts Payable > Vendors > New Vendor now populates correctly, and the selected value saves successfully.