### PR TITLE
Fix #228 Do not allow duplicate account numbers in the chart of account

### DIFF
--- a/src/Api/Controllers/FinancialsController.cs
+++ b/src/Api/Controllers/FinancialsController.cs
@@ -424,7 +424,15 @@ namespace Api.Controllers
                 // CreditBalance = 0
             };
 
-            var createdAccount = await _accountService.AddAccountAsync(newAccount);
+            Core.Domain.Financials.Account createdAccount;
+            try
+            {
+                createdAccount = await _accountService.AddAccountAsync(newAccount);
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Conflict(new { message = ex.Message });
+            }
 
             // Return a DTO instead of the domain object to avoid serialization issues with computed properties
             var accountDto = new Account

--- a/src/Api/Service/AccountService.cs
+++ b/src/Api/Service/AccountService.cs
@@ -47,6 +47,14 @@ public class AccountService : IAccountService
             newAccount.DrOrCrSide = Core.Domain.DrOrCrSide.Dr;
         }
 
+        // Check for duplicate account code
+        var existingAccount = await _context.Accounts
+            .AnyAsync(a => a.AccountCode == newAccount.AccountCode);
+        if (existingAccount)
+        {
+            throw new InvalidOperationException($"Account number '{newAccount.AccountCode}' already exists.");
+        }
+
         _context.Accounts.Add(newAccount);
         await _context.SaveChangesAsync();
         return newAccount;


### PR DESCRIPTION
Under Financials -> Chart of Accounts:

- Checks for duplicate account and throws error message if duplicate is found