### PR TITLE
Double Click Rows To View/Edit The Item

### DIFF
--- a/src/AccountGoWeb/Components/Pages/Audit/AuditableEntities.razor
+++ b/src/AccountGoWeb/Components/Pages/Audit/AuditableEntities.razor
@@ -4,6 +4,7 @@
 @using System.Text.Json
 @inject IHttpClientFactory ClientFactory
 @inject IConfiguration Configuration
+@inject NavigationManager Navigation
 
 <PageTitle>Auditable Entities</PageTitle>
 
@@ -55,7 +56,7 @@ else
                                 <tbody>
                                     @foreach (var entity in entities)
                                     {
-                                        <tr>
+                                        <tr @ondblclick="() => NavigateToAuditableEntity(entity)" style="cursor: pointer;">
                                             <td>@entity.Id</td>
                                             <td>@entity.EntityName</td>
                                             <td>
@@ -69,9 +70,6 @@ else
                                                 }
                                             </td>
                                             <td>
-                                                <a href="/Audit/GetEntity?id=@entity.Id" class="btn btn-sm btn-info" style="margin-right: 5px;">
-                                                    <i class="fa fa-edit"></i> Edit
-                                                </a>
                                                 <a href="/Audit/GetAuditableAttributes?entityId=@entity.Id" class="btn btn-sm btn-success" style="margin-right: 5px;">
                                                     <i class="fa fa-list"></i> Attributes
                                                 </a>
@@ -177,6 +175,14 @@ else
         isDeleteModalVisible = false;
         selectedEntity = null;
         errorMessage = string.Empty;
+    }
+
+    private void NavigateToAuditableEntity(AuditableEntity entity)
+    {
+        if (entity != null)
+        {
+            Navigation.NavigateTo($"/Audit/GetEntity?id={entity.Id}", forceLoad: true);
+        }
     }
 
     private async Task ConfirmDeleteEntity()

--- a/src/AccountGoWeb/Components/Pages/Donations/DonationInvoices.razor
+++ b/src/AccountGoWeb/Components/Pages/Donations/DonationInvoices.razor
@@ -178,7 +178,8 @@ else if (donationInvoices != null && donationInvoices.Any())
                     @foreach (var invoice in donationInvoices)
                     {
                         <tr class="@(selectedInvoice?.Id == invoice.Id ? "table-active" : "")"
-                            @onclick="() => SelectInvoice(invoice)">
+                            @onclick="() => SelectInvoice(invoice)"
+                            @ondblclick="() => NavigateToDonationInvoice(invoice)">
                             <td class="text-center">
                                 <input type="radio" name="selectedInvoice" checked="@(selectedInvoice?.Id == invoice.Id)" />
                             </td>
@@ -329,6 +330,16 @@ else
     {
         selectedInvoice = invoice;
         StateHasChanged();
+    }
+
+    private void NavigateToDonationInvoice(DonationInvoice invoice) 
+    {
+        SelectInvoice(invoice);
+        if (selectedInvoice != null)
+        {
+            NavigationManager.NavigateTo($"/donations/donationinvoice?id={selectedInvoice.Id}");
+            NavigationManager.Refresh();
+        }
     }
 
     private void EditInvoice()

--- a/src/AccountGoWeb/Components/Pages/Donations/DonationInvoices.razor
+++ b/src/AccountGoWeb/Components/Pages/Donations/DonationInvoices.razor
@@ -337,8 +337,7 @@ else
         SelectInvoice(invoice);
         if (selectedInvoice != null)
         {
-            NavigationManager.NavigateTo($"/donations/donationinvoice?id={selectedInvoice.Id}");
-            NavigationManager.Refresh();
+            NavigationManager.NavigateTo($"/donations/donationinvoice?id={selectedInvoice.Id}", forceLoad: true);
         }
     }
 

--- a/src/AccountGoWeb/Components/Pages/Financial/JournalEntries.razor
+++ b/src/AccountGoWeb/Components/Pages/Financial/JournalEntries.razor
@@ -5,6 +5,7 @@
 
 @inject HttpClient Http
 @inject IConfiguration Config
+@inject NavigationManager Navigation
 
 <div>
     <a href="/Financials/AddJournalEntry" class="btn btn-primary me-2">
@@ -57,7 +58,8 @@
                         var isSelected = SelectedEntry?.Id == e.Id;
 
                         <tr class="@(isSelected ? "table-primary" : "")" style="cursor: pointer;"
-                            @onclick="@(() => OnRowClick(e))">
+                            @onclick="@(() => OnRowClick(e))"
+                            @ondblclick="NavigateToFinancialJournalEntry">
 
                             <td>@e.Id</td>
                             <td>@e.VoucherType</td>
@@ -123,5 +125,13 @@
     private void OnRowClick(JournalEntryDto entry)
     {
         SelectedEntry = entry;
+    }
+
+    private void NavigateToFinancialJournalEntry()
+    {
+        if (SelectedEntry != null) 
+        {
+            Navigation.NavigateTo($"/Financials/JournalEntry?id={SelectedEntry.Id}", forceLoad: true);
+        }
     }
 }

--- a/src/AccountGoWeb/Components/Pages/Inventory/Items.razor
+++ b/src/AccountGoWeb/Components/Pages/Inventory/Items.razor
@@ -1,6 +1,8 @@
 @using Dto.Inventory
 @inject HttpClient Http
 
+@inject NavigationManager Navigation
+
 <style>
     .table tbody tr.table-active {
         background-color: #0d6efd !important;
@@ -112,6 +114,7 @@
                             @foreach (var item in items)
                             {
                                 <tr @onclick="() => SelectItem(item)"
+                                    @ondblclick="NavigateToInventoryItem"
                                     class="@(selectedItem?.Id == item.Id ? "table-active" : "")" style="cursor: pointer;">
 
                                     <td>
@@ -200,6 +203,14 @@
     private void SelectItem(Item item)
     {
         selectedItem = item;
+    }
+
+    private void NavigateToInventoryItem()
+    {
+        if (selectedItem != null)
+        {
+            Navigation.NavigateTo($"/Inventory/Item/{selectedItem.Id}", forceLoad: true);
+        }
     }
 
     private void SortBy(string column)

--- a/src/AccountGoWeb/Components/Pages/Payables/PurchaseInvoicesList.razor
+++ b/src/AccountGoWeb/Components/Pages/Payables/PurchaseInvoicesList.razor
@@ -62,9 +62,6 @@ else
                         <td>@("$" + invoice.AmountPaid.ToString("N2"))</td>
                         <td>@invoice.ReferenceNo</td>
                         <td>
-                            <a href="/purchasing/purchaseinvoice?id=@invoice.Id" class="btn btn-sm btn-outline-primary" @onclick:stopPropagation="true">
-                                View
-                            </a>
                             @if (!invoice.IsPaid && invoice.Posted)
                             {
                                 <a href="/purchasing/payment/@invoice.Id" class="btn btn-sm btn-outline-success" @onclick:stopPropagation="true">

--- a/src/AccountGoWeb/Components/Pages/Payables/PurchaseInvoicesList.razor
+++ b/src/AccountGoWeb/Components/Pages/Payables/PurchaseInvoicesList.razor
@@ -3,6 +3,8 @@
 @using System.Text.Json.Serialization
 @inject IHttpClientFactory ClientFactory
 
+@inject NavigationManager Navigation
+
 @if (getError)
 {
     <div class="alert alert-danger" role="alert">
@@ -50,6 +52,7 @@ else
                 @foreach (var invoice in purchaseInvoices)
                 {
                     <tr @onclick="() => SelectInvoice(invoice)" 
+                        @ondblclick="NavigateToPurchaseInvoice"
                         class="@(selectedInvoice?.Id == invoice.Id ? "table-active" : "")"
                         style="cursor: pointer;">
                         <td>@invoice.No</td>
@@ -134,6 +137,14 @@ else
     {
         selectedInvoice = invoice;
         StateHasChanged();
+    }
+
+    private void NavigateToPurchaseInvoice()
+    {
+        if (selectedInvoice != null)
+        {
+            Navigation.NavigateTo($"/purchasing/purchaseinvoice?id={selectedInvoice.Id}", forceLoad: true);
+        }
     }
 
     public class PurchaseInvoiceDto

--- a/src/AccountGoWeb/Components/Pages/Payables/PurchaseOrdersList.razor
+++ b/src/AccountGoWeb/Components/Pages/Payables/PurchaseOrdersList.razor
@@ -50,6 +50,7 @@ else
                 @foreach (var order in purchaseOrders)
                 {
                     <tr @onclick="() => SelectOrder(order)" 
+                        @ondblclick="NavigateToPurchaseOrder"
                         class="@(selectedPurchaseOrder?.Id == order.Id ? "table-active" : "")"
                         style="cursor: pointer;">
                         <td>@order.No</td>
@@ -127,6 +128,14 @@ else
     {
         selectedPurchaseOrder = order;
         StateHasChanged();
+    }
+
+    private void NavigateToPurchaseOrder()
+    {
+        if (selectedPurchaseOrder != null)
+        {
+            Navigation.NavigateTo($"/purchasing/purchaseorder?id={selectedPurchaseOrder.Id}", forceLoad: true);
+        }
     }
 
     public class PurchaseOrderDto

--- a/src/AccountGoWeb/Components/Pages/Payables/PurchaseOrdersList.razor
+++ b/src/AccountGoWeb/Components/Pages/Payables/PurchaseOrdersList.razor
@@ -43,7 +43,6 @@ else
                     <th>Order Date</th>
                     <th>Amount</th>
                     <th>Ref No</th>
-                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -58,11 +57,6 @@ else
                         <td>@order.OrderDate.ToString("yyyy-MM-dd")</td>
                         <td>@("$" + order.Amount.ToString("N2"))</td>
                         <td>@order.ReferenceNo</td>
-                        <td>
-                            <a href="/purchasing/purchaseorder?id=@order.Id" class="btn btn-sm btn-outline-primary" @onclick:stopPropagation="true">
-                                View
-                            </a>
-                        </td>
                     </tr>
                 }
             </tbody>

--- a/src/AccountGoWeb/Components/Pages/Purchasing/Vendors.razor
+++ b/src/AccountGoWeb/Components/Pages/Purchasing/Vendors.razor
@@ -1,6 +1,8 @@
 @using Dto.Purchasing
 @inject HttpClient Http
 
+@inject NavigationManager Navigation
+
 <style>
     .table tbody tr.table-active {
         background-color: #0d6efd !important;
@@ -106,6 +108,7 @@
                             @foreach (var vendor in vendors)
                             {
                                 <tr @onclick="() => SelectVendor(vendor)"
+                                    @ondblclick="NavigateToPurshaseVendor"
                                     class="@(selectedVendor?.Id == vendor.Id ? "table-active" : "")" style="cursor: pointer;">
 
                                     <td>
@@ -192,6 +195,14 @@
     private void SelectVendor(Vendor vendor)
     {
         selectedVendor = vendor;
+    }
+
+    private void NavigateToPurshaseVendor()
+    {
+        if (selectedVendor != null)
+        {
+            Navigation.NavigateTo($"/purchasing/vendor/{selectedVendor.Id}", forceLoad: true);
+        }
     }
 
     private void SortBy(string column)

--- a/src/AccountGoWeb/Components/Pages/Quotations/SalesQuotations.razor
+++ b/src/AccountGoWeb/Components/Pages/Quotations/SalesQuotations.razor
@@ -23,6 +23,7 @@
 }
 .quotationRow:hover {
     background-color: rgba(255,255,255,0.1); /* optional hover effect */
+    cursor: pointer;
 }
 </style>
 

--- a/src/AccountGoWeb/Components/Pages/Quotations/SalesQuotations.razor
+++ b/src/AccountGoWeb/Components/Pages/Quotations/SalesQuotations.razor
@@ -79,7 +79,7 @@ else
         @foreach (var q in quotations)
         {
             <tr @onclick="() => OnSelectionChanged(q.id, q.statusId)" 
-                @ondblclick="() => NavigateToQuotation(q.id)"
+                @ondblclick="() => NavigateToSalesQuotation(q.id)"
                 class="quotationRow">
                 <td>@q.no</td>
                 <td>@q.customerName</td>
@@ -150,7 +150,7 @@ protected override async Task OnInitializedAsync()
         }
     }
 
-    private void NavigateToQuotation(int id)
+    private void NavigateToSalesQuotation(int id)
     {
         NavigationManager.NavigateTo($"/quotations/quotation?id={id}");
         NavigationManager.Refresh();

--- a/src/AccountGoWeb/Components/Pages/Quotations/SalesQuotations.razor
+++ b/src/AccountGoWeb/Components/Pages/Quotations/SalesQuotations.razor
@@ -152,8 +152,7 @@ protected override async Task OnInitializedAsync()
 
     private void NavigateToSalesQuotation(int id)
     {
-        NavigationManager.NavigateTo($"/quotations/quotation?id={id}");
-        NavigationManager.Refresh();
+        NavigationManager.NavigateTo($"/quotations/quotation?id={id}", forceLoad: true);
     }
 
     // DTO class for deserialization

--- a/src/AccountGoWeb/Components/Pages/Quotations/SalesQuotations.razor
+++ b/src/AccountGoWeb/Components/Pages/Quotations/SalesQuotations.razor
@@ -78,7 +78,9 @@ else
     <tbody>
         @foreach (var q in quotations)
         {
-            <tr @onclick="() => OnSelectionChanged(q.id, q.statusId)" class="quotationRow">
+            <tr @onclick="() => OnSelectionChanged(q.id, q.statusId)" 
+                @ondblclick="() => NavigateToQuotation(q.id)"
+                class="quotationRow">
                 <td>@q.no</td>
                 <td>@q.customerName</td>
                 <td>@q.quotationDate.ToShortDateString()</td>
@@ -146,6 +148,12 @@ protected override async Task OnInitializedAsync()
             newOrderLink = $"/sales/salesorder?quotationId={id}";
             isNewOrderLinkActive = true;
         }
+    }
+
+    private void NavigateToQuotation(int id)
+    {
+        NavigationManager.NavigateTo($"/quotations/quotation?id={id}");
+        NavigationManager.Refresh();
     }
 
     // DTO class for deserialization

--- a/src/AccountGoWeb/Components/Pages/Sales/Customers.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/Customers.razor
@@ -84,6 +84,7 @@
                             @foreach (var customer in customers)
                             {
                                 <tr @onclick="() => SelectCustomer(customer)"
+                                    @ondblclick="() => NavigateToViewCustomer()"
                                     style="cursor: pointer; @(selectedCustomer?.Id == customer.Id ? "background-color: #007bff33; border-left: 3px solid #007bff;" : "")">
                                     <td>
                                         <a href="/sales/customer/@customer.Id">

--- a/src/AccountGoWeb/Components/Pages/Sales/SalesOrders.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/SalesOrders.razor
@@ -81,7 +81,7 @@
                             <tr 
                                 class="@(selectedRowIndex == index ? "selected" : "")" 
                                 @onclick="@(() => OnRowSelected(index))"
-                                @ondblclick="@(() => NavigateToOrder(index))">
+                                @ondblclick="@(() => NavigateToSalesOrder(index))">
                                 <td>@GetValue(salesOrders[index], "no")</td>
                                 <td>@GetValue(salesOrders[index], "customerName")</td>
                                 <td>@GetValue(salesOrders[index], "orderDate")</td>
@@ -295,7 +295,7 @@
         StateHasChanged();
     }
 
-    private void NavigateToOrder(int index)
+    private void NavigateToSalesOrder(int index)
     {
         if (index >= 0 && index < salesOrders.Count)
         {

--- a/src/AccountGoWeb/Components/Pages/Sales/SalesOrders.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/SalesOrders.razor
@@ -303,8 +303,7 @@
             
             if (selectedOrderId != null) 
             {
-                Navigation.NavigateTo($"/Sales/SalesOrder?id={selectedOrderId}");
-                Navigation.Refresh();
+                Navigation.NavigateTo($"/Sales/SalesOrder?id={selectedOrderId}", forceLoad: true);
             }
 
         }

--- a/src/AccountGoWeb/Components/Pages/Sales/SalesOrders.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/SalesOrders.razor
@@ -300,9 +300,13 @@
         if (index >= 0 && index < salesOrders.Count)
         {
             OnRowSelected(index);
+            
+            if (selectedOrderId != null) 
+            {
+                Navigation.NavigateTo($"/Sales/SalesOrder?id={selectedOrderId}");
+                Navigation.Refresh();
+            }
 
-            Navigation.NavigateTo($"/Sales/SalesOrder?id={selectedOrderId}");
-            Navigation.Refresh();
         }
     }
     private void UpdateButtonLinks()

--- a/src/AccountGoWeb/Components/Pages/Sales/SalesOrders.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/SalesOrders.razor
@@ -78,7 +78,10 @@
                         @for (int i = 0; i < salesOrders.Count; i++)
                         {
                             int index = i;
-                            <tr class="@(selectedRowIndex == index ? "selected" : "")" @onclick="@(() => OnRowSelected(index))">
+                            <tr 
+                                class="@(selectedRowIndex == index ? "selected" : "")" 
+                                @onclick="@(() => OnRowSelected(index))"
+                                @ondblclick="@(() => NavigateToOrder(index))">
                                 <td>@GetValue(salesOrders[index], "no")</td>
                                 <td>@GetValue(salesOrders[index], "customerName")</td>
                                 <td>@GetValue(salesOrders[index], "orderDate")</td>
@@ -290,6 +293,17 @@
         }
 
         StateHasChanged();
+    }
+
+    private void NavigateToOrder(int index)
+    {
+        if (index >= 0 && index < salesOrders.Count)
+        {
+            OnRowSelected(index);
+
+            Navigation.NavigateTo($"/Sales/SalesOrder?id={selectedOrderId}");
+            Navigation.Refresh();
+        }
     }
     private void UpdateButtonLinks()
     {

--- a/src/AccountGoWeb/Components/Pages/Sales/SalesReceipts.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/SalesReceipts.razor
@@ -79,7 +79,10 @@
                         @for (int i = 0; i < salesReceipts.Count; i++)
                         {
                             int index = i;
-                            <tr class="@(selectedRowIndex == index ? "selected-row" : "")" @onclick="@(() => OnRowSelected(index))">
+                            <tr 
+                                class="@(selectedRowIndex == index ? "selected-row" : "")" 
+                                @onclick="@(() => OnRowSelected(index))"
+                                @ondblclick="@(() => NavigateToReceipt(index))">
                                 <td>@GetValue(salesReceipts[index], "id")</td>
                                 <td>@GetValue(salesReceipts[index], "receiptNo")</td>
                                 <td>@GetValue(salesReceipts[index], "customerName")</td>
@@ -301,6 +304,20 @@
         catch
         {
             selectedReceiptId = null;
+        }
+    }
+
+    private void NavigateToReceipt(int index)
+    {
+        if (index >= 0 && index < salesReceipts.Count)
+        {
+            OnRowSelected(index);
+
+            if (selectedReceiptId != null)
+            {
+                Navigation.NavigateTo($"/Sales/SalesReceipt?id={selectedReceiptId}");
+                Navigation.Refresh();
+            }
         }
     }
 

--- a/src/AccountGoWeb/Components/Pages/Sales/SalesReceipts.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/SalesReceipts.razor
@@ -315,8 +315,7 @@
 
             if (selectedReceiptId != null)
             {
-                Navigation.NavigateTo($"/Sales/SalesReceipt?id={selectedReceiptId}");
-                Navigation.Refresh();
+                Navigation.NavigateTo($"/Sales/SalesReceipt?id={selectedReceiptId}", forceLoad: true);
             }
         }
     }

--- a/src/AccountGoWeb/Components/Pages/Sales/SalesReceipts.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/SalesReceipts.razor
@@ -82,7 +82,7 @@
                             <tr 
                                 class="@(selectedRowIndex == index ? "selected-row" : "")" 
                                 @onclick="@(() => OnRowSelected(index))"
-                                @ondblclick="@(() => NavigateToReceipt(index))">
+                                @ondblclick="@(() => NavigateToSalesReceipt(index))">
                                 <td>@GetValue(salesReceipts[index], "id")</td>
                                 <td>@GetValue(salesReceipts[index], "receiptNo")</td>
                                 <td>@GetValue(salesReceipts[index], "customerName")</td>
@@ -307,7 +307,7 @@
         }
     }
 
-    private void NavigateToReceipt(int index)
+    private void NavigateToSalesReceipt(int index)
     {
         if (index >= 0 && index < salesReceipts.Count)
         {

--- a/src/AccountGoWeb/Components/Pages/Tax/TaxManagement.razor
+++ b/src/AccountGoWeb/Components/Pages/Tax/TaxManagement.razor
@@ -52,12 +52,11 @@
                             {
                                 @foreach (var tax in taxes)
                                 {
-                                    <tr>
+                                    <tr @ondblclick="() => EditTax(tax)" style="cursor: pointer;">
                                         <td>@tax.TaxCode</td>
                                         <td>@tax.TaxName</td>
                                         <td>@tax.Rate</td>
                                         <td>
-                                            <button class="btn btn-sm btn-info btn-flat" @onclick="() => EditTax(tax)">Edit</button>
                                             <button class="btn btn-sm btn-danger btn-flat"
                                                 @onclick="() => ConfirmDeleteTax(tax.Id)">Delete</button>
                                         </td>

--- a/src/AccountGoWeb/Views/Sales/SalesInvoices.cshtml
+++ b/src/AccountGoWeb/Views/Sales/SalesInvoices.cshtml
@@ -108,6 +108,7 @@
             // PROPERTIES - simple boolean / string / number properties
             rowSelection: 'single',
             onSelectionChanged: onSelectionChanged,
+            onRowDoubleClicked: navigateToSalesInvoice,
             theme: 'legacy' // Use v32 style themes to match ag-grid.css
         };
 
@@ -125,6 +126,14 @@
                 document.getElementById('linkDeleteInvoice').setAttribute('data-bs-toggle', 'modal');
                 document.getElementById('linkDeleteInvoice').setAttribute('data-bs-target', '#deleteSalesInvoice');
                 $("#hdnselectedsalesInvoiceId").val(selectedRow.id);
+            }
+        }
+
+        function navigateToSalesInvoice(event) {
+            var selectedRow = event.data;
+            onSelectionChanged();
+            if (selectedRow) {
+                location.href = 'Sales/SalesInvoice?id=' + selectedRow.id;
             }
         }
 

--- a/src/AccountGoWeb/Views/Sales/SalesInvoices.cshtml
+++ b/src/AccountGoWeb/Views/Sales/SalesInvoices.cshtml
@@ -6,6 +6,12 @@
         color: white;
         border-color: aqua;
         opacity: 0.9;
+        cursor: pointer;
+    }
+    
+    .ag-row-hover,
+    .ag-row-focus {
+        cursor: pointer;
     }
 </style>
 


### PR DESCRIPTION
Fixes #211 

### Summary

- MVC pages with similar tables and rows like Sales Quotations (Accounts Receivable >> Sales Quotations) now have a double click event for each row that allows the user to view/edit the given item.

### Changes

- Most pages have an additional function call that either uses the selected item or ID for that given item to navigate to the edit/view page with the ID of that item.

  - The \<tr\> tag contains the `@ondblclick=""` event that is passed the NavigateTo{Item} function (eg. `@ondblclick="() => NavigateToAuditableEntity(entity)"`).
  - The  NavigateTo{Item} function utilizes the NavigationManager injected at the top of the pages to move the user to the edit/view page.
  - The NavigateTo() function is called from the manager with the URL string, the ID and the `forceLoad: true` option.

- Pages with an action button to view/edit them have been removed.
  - Pages with an action column that **only** have a view/edit button have been removed entirely.

- Pages that have been changed like Sales Quotations that did not have the `cursor: pointer` styling before will now have it for their rows.

### Caveats

- I wasn't able to create the double click event for the Security Users page because I couldn't login using the admin user credentials.

- Chart of Accounts page doesn't have a double click event as it would also close the expanded account. Let me know if you have a particular solution for this situation.

Demo 1:

- Existing single click events should still work.
- Double click events demonstrated here.

https://github.com/user-attachments/assets/d171e32b-7739-4575-ac60-4654f72b4b27

Demo 2:

- Double click events don't intefere with existing buttons in the item row.

https://github.com/user-attachments/assets/1013cfa8-0683-4c81-a164-87fe54f4571a
