### PR TITLE
fixed issue 214 changed the term measurement to unit across the site

### DIFF
--- a/src/AccountGoWeb/Components/Pages/Donations/AddDonationInvoice.razor
+++ b/src/AccountGoWeb/Components/Pages/Donations/AddDonationInvoice.razor
@@ -236,7 +236,7 @@ else if (invoice != null)
                             <th>Item</th>
                             <th>Quantity</th>
                             <th>Amount</th>
-                            <th>Measurement</th>
+                                    <th>Unit</th>
                             <th>Notes</th>
                             <th></th>
                         </tr>

--- a/src/AccountGoWeb/Components/Pages/Inventory/ICJ.razor
+++ b/src/AccountGoWeb/Components/Pages/Inventory/ICJ.razor
@@ -23,7 +23,7 @@ else
             <tr>
                 <th>Id</th>
                 <th>Item</th>
-                <th>Measurement</th>
+                <th>Unit</th>
                 <th>IN</th>
                 <th>OUT</th>
                 <th>Date</th>

--- a/src/AccountGoWeb/Components/Pages/Inventory/Items.razor
+++ b/src/AccountGoWeb/Components/Pages/Inventory/Items.razor
@@ -91,7 +91,7 @@
                                     Description @GetSortIcon(nameof(Item.Description))
                                 </th>
                                 <th @onclick="() => SortBy(nameof(Item.Measurement))" style="cursor: pointer;">
-                                    Measurement @GetSortIcon(nameof(Item.Measurement))
+                                    Unit @GetSortIcon(nameof(Item.Measurement))
                                 </th>
                                 <th @onclick="() => SortBy(nameof(Item.ItemTaxGroupName))" style="cursor: pointer;">
                                     Item Tax Group @GetSortIcon(nameof(Item.ItemTaxGroupName))

--- a/src/AccountGoWeb/Components/Pages/Payables/PurchaseInvoiceForm.razor
+++ b/src/AccountGoWeb/Components/Pages/Payables/PurchaseInvoiceForm.razor
@@ -103,7 +103,7 @@ else
                                 <th>Quantity</th>
                                 <th>Amount</th>
                                 <th>Discount</th>
-                                <th>Measurement</th>
+                                    <th>Unit</th>
                                 @if (!isViewMode)
                                 {
                                     <th>Actions</th>
@@ -139,7 +139,7 @@ else
                                 </td>
                                 <td style="background-color: transparent !important;">
                                     <InputSelect class="form-control" @bind-Value="line.MeasurementId" disabled="@isViewMode">
-                                        <option value="0">-- Select Measurement --</option>
+                                            <option value="0">-- Select Unit --</option>
                                         @if (measurements != null)
                                         {
                                             @foreach (var measurement in measurements)

--- a/src/AccountGoWeb/Components/Pages/Payables/PurchaseOrderForm.razor
+++ b/src/AccountGoWeb/Components/Pages/Payables/PurchaseOrderForm.razor
@@ -116,7 +116,7 @@ else
                                 <th>Quantity</th>
                                 <th>Amount</th>
                                 <th>Discount</th>
-                                <th>Measurement</th>
+                                    <th>Unit</th>
                                 @if (!isViewMode)
                                 {
                                     <th>Actions</th>
@@ -152,7 +152,7 @@ else
                                 </td>
                                 <td style="background-color: transparent !important;">
                                     <InputSelect class="form-control" @bind-Value="line.MeasurementId" disabled="@isViewMode">
-                                        <option value="0">-- Select Measurement --</option>
+                                            <option value="0">-- Select Unit --</option>
                                         @if (measurements != null)
                                         {
                                             @foreach (var measurement in measurements)

--- a/src/AccountGoWeb/Components/Pages/Quotations/AddSalesQuotation.razor
+++ b/src/AccountGoWeb/Components/Pages/Quotations/AddSalesQuotation.razor
@@ -52,7 +52,7 @@
                         <th>Quantity</th>
                         <th>Amount</th>
                         <th>Discount</th>
-                        <th>Measurement</th>
+                        <th>Unit</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/AccountGoWeb/Components/Pages/Sales/NewSalesOrder.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/NewSalesOrder.razor
@@ -81,7 +81,7 @@
                                         <th>Quantity</th>
                                         <th>Amount</th>
                                         <th>Discount (%)</th>
-                                        <th>Measurement</th>
+                                    <th>Unit</th>
                                         <th>Action</th>
                                     </tr>
                                 </thead>
@@ -115,7 +115,7 @@
                                                 </td>
                                                 <td>
                                                     <select class="form-control form-control-sm" @bind="line.MeasurementId">
-                                                        <option value="0">-- Select Measurement --</option>
+                                            <option value="0">-- Select Unit --</option>
                                                         @foreach (var measurement in measurements)
                                                         {
                                                             <option value="@measurement.id">@measurement.description</option>
@@ -319,7 +319,7 @@
         }
         catch (Exception ex)
         {
-            errorMessage = $"Error loading measurements: {ex.Message}";
+            errorMessage = $"Error loading units: {ex.Message}";
         }
     }
 

--- a/src/AccountGoWeb/Components/Pages/Sales/SalesInvoice.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/SalesInvoice.razor
@@ -89,7 +89,7 @@
                                         <th>Quantity</th>
                                         <th>Amount</th>
                                         <th>Discount (%)</th>
-                                        <th>Measurement</th>
+                                    <th>Unit</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -121,7 +121,7 @@
                                                 </td>
                                                 <td>
                                                     <select class="form-control form-control-sm" @bind="line.MeasurementId">
-                                                        <option value="0">-- Select Measurement --</option>
+                                            <option value="0">-- Select Unit --</option>
                                                         @foreach (var measurement in measurements)
                                                         {
                                                             <option value="@measurement.id">@measurement.description</option>
@@ -305,7 +305,7 @@
         }
         catch (Exception ex)
         {
-            errorMessage = $"Error loading measurements: {ex.Message}";
+            errorMessage = $"Error loading units: {ex.Message}";
         }
     }
 
@@ -477,7 +477,7 @@
             0).ToList();
             if (invalidLines.Any())
             {
-                errorMessage = "All line items must have Item, Measurement, Quantity, and Amount selected";
+            errorMessage = "All line items must have Item, Unit, Quantity, and Amount selected";
                 StateHasChanged();
                 return;
             }

--- a/src/AccountGoWeb/Components/Pages/Sales/SalesOrder.razor
+++ b/src/AccountGoWeb/Components/Pages/Sales/SalesOrder.razor
@@ -75,7 +75,7 @@
                                     <th>Quantity</th>
                                     <th>Amount</th>
                                     <th>Discount</th>
-                                    <th>Measurement</th>
+                                <th>Unit</th>
                                 </tr>
                             </thead>
                             <tbody>

--- a/src/AccountGoWeb/Views/Donations/DonationInvoice.cshtml
+++ b/src/AccountGoWeb/Views/Donations/DonationInvoice.cshtml
@@ -96,7 +96,7 @@
                     <th>Item</th>
                     <th>Quantity</th>
                     <th>Amount</th>
-                    <th>Measurement</th>
+                <th>Unit</th>
                     <th>Notes</th>
                 </thead>
                 <tbody>

--- a/src/AccountGoWeb/Views/Inventory/addItem.cshtml
+++ b/src/AccountGoWeb/Views/Inventory/addItem.cshtml
@@ -82,7 +82,7 @@
                 </div>
                 @* Smallest Measurement *@
                 <div class="row">
-                    <div class="col-sm-3">Smallest Measurement</div>
+                <div class="col-sm-3">Smallest Unit</div>
                     <div class="col-sm-8">
                         <select class="form-control" asp-for="SmallestMeasurementId" asp-items="ViewBag.Measurements"></select>
                         <span asp-validation-for="SmallestMeasurementId" class="danger"></span>
@@ -90,7 +90,7 @@
                 </div>
                 @* Purchase Measurement *@
                 <div class="row">
-                    <div class="col-sm-3">Purchase Measurement</div>
+                <div class="col-sm-3">Purchase Unit</div>
                     <div class="col-sm-8">
                         <select class="form-control" asp-for="PurchaseMeasurementId" asp-items="ViewBag.Measurements"></select>
                         <span asp-validation-for="PurchaseMeasurementId" class="danger"></span>

--- a/src/AccountGoWeb/Views/Quotations/Quotation.cshtml
+++ b/src/AccountGoWeb/Views/Quotations/Quotation.cshtml
@@ -63,7 +63,7 @@
                         <th>Quantity</th>
                         <th>Amount</th>
                         <th>Discount</th>
-                        <th>Measurement</th>
+                <th>Unit</th>
                     </thead>
                     <tbody>
                         @for (int i = 0; i < Model.SalesQuotationLines.Count; i++)

--- a/src/AccountGoWeb/Views/Sales/DonationInvoice.cshtml
+++ b/src/AccountGoWeb/Views/Sales/DonationInvoice.cshtml
@@ -60,7 +60,7 @@
                     <th>Quantity</th>
                     <th>Amount</th>
                     <th>Discount</th>
-                    <th>Measurement</th>
+                <th>Unit</th>
                 </thead>
                 <tbody>
                     @for (int i = 0; i < Model.SalesInvoiceLines!.Count; i++)

--- a/src/AccountGoWeb/Views/Sales/SalesInvoicePdf.cshtml
+++ b/src/AccountGoWeb/Views/Sales/SalesInvoicePdf.cshtml
@@ -108,7 +108,7 @@ apply the skin class to the body tag so the changes take effect.
                         <tr>
                             <th>Quantity</th>
                             <th>Product</th>
-                            <th>Measurement</th>
+                <th>Unit</th>
                             <th>Description</th>
                             <th>Subtotal (before tax)</th>
                         </tr>

--- a/src/BlazorGDB/BlazorGDB/Components/Pages/Inventory/Items.razor
+++ b/src/BlazorGDB/BlazorGDB/Components/Pages/Inventory/Items.razor
@@ -76,7 +76,7 @@
                                     Description @GetSortIcon(nameof(Item.Description))
                                 </th>
                                 <th @onclick="() => SortBy(nameof(Item.Measurement))">
-                                    Measurement @GetSortIcon(nameof(Item.Measurement))
+                            Unit @GetSortIcon(nameof(Item.Measurement))
                                 </th>
                                 <th @onclick="() => SortBy(nameof(Item.ItemTaxGroupName))">
                                     Item Tax Group @GetSortIcon(nameof(Item.ItemTaxGroupName))

--- a/src/BlazorGDB/BlazorGDB/Components/Pages/Payables/PurchaseInvoiceDetail.razor
+++ b/src/BlazorGDB/BlazorGDB/Components/Pages/Payables/PurchaseInvoiceDetail.razor
@@ -112,7 +112,7 @@ else
                             <th>Quantity</th>
                             <th>Amount</th>
                             <th>Discount %</th>
-                            <th>Measurement</th>
+                                    <th>Unit</th>
                             @if (!isViewMode)
                             {
                                 <th>Actions</th>
@@ -159,7 +159,7 @@ else
                                         @if (measurements != null && measurements.Any())
                                         {
                                             <InputSelect class="form-control" @bind-Value="line.MeasurementId" disabled="@isViewMode">
-                                                <option value="0">-- Select Measurement --</option>
+                                                    <option value="0">-- Select Unit --</option>
                                                 @foreach (var measurement in measurements)
                                                 {
                                                     <option value="@measurement.Id">@measurement.Name</option>

--- a/src/BlazorGDB/BlazorGDB/Components/Pages/Payables/PurchaseOrderDetail.razor
+++ b/src/BlazorGDB/BlazorGDB/Components/Pages/Payables/PurchaseOrderDetail.razor
@@ -91,7 +91,7 @@ else
                             <th>Quantity</th>
                             <th>Amount</th>
                             <th>Discount %</th>
-                            <th>Measurement</th>
+                                    <th>Unit</th>
                             @if (!isViewMode)
                             {
                                 <th>Actions</th>
@@ -138,7 +138,7 @@ else
                                         @if (measurements != null && measurements.Any())
                                         {
                                             <InputSelect class="form-control" @bind-Value="line.MeasurementId" disabled="@isViewMode">
-                                                <option value="0">-- Select Measurement --</option>
+                                                    <option value="0">-- Select Unit --</option>
                                                 @foreach (var measurement in measurements)
                                                 {
                                                     <option value="@measurement.Id">@measurement.Name</option>

--- a/src/GoodBooksReact/src/components/Purchasing/PurchaseInvoice.tsx
+++ b/src/GoodBooksReact/src/components/Purchasing/PurchaseInvoice.tsx
@@ -303,7 +303,7 @@ class PurchaseInvoiceLines extends React.Component {
                                 <td>No</td>
                                 <td>Item Id</td>
                                 <td>Item Name</td>
-                                <td>Measurement</td>
+                                <td>Unit</td>
                                 <td>Quantity</td>
                                 <td>Amount</td>
                                 <td>Discount</td>

--- a/src/GoodBooksReact/src/components/Purchasing/PurchaseOrder.tsx
+++ b/src/GoodBooksReact/src/components/Purchasing/PurchaseOrder.tsx
@@ -217,7 +217,7 @@ class PurchaseOrderLines extends React.Component {
                                 <td>No</td>
                                 <td>Item Id</td>
                                 <td>Code</td>
-                                <td>Measurement</td>
+                                <td>Unit</td>
                                 <td>Quantity</td>
                                 <td>Amount</td>
                                 <td>Discount</td>

--- a/src/GoodBooksReact/src/components/Sales/SalesInvoice.tsx
+++ b/src/GoodBooksReact/src/components/Sales/SalesInvoice.tsx
@@ -292,7 +292,7 @@ class SalesInvoiceLines extends React.Component {
                                 <td>No</td>
                                 <td>Item Id</td>
                                 <td>Code</td>
-                                <td>Measurement</td>
+                                <td>Unit</td>
                                 <td>Quantity</td>
                                 <td>Amount</td>
                                 <td>Discount</td>

--- a/src/GoodBooksReact/src/components/Sales/SalesOrder.tsx
+++ b/src/GoodBooksReact/src/components/Sales/SalesOrder.tsx
@@ -280,7 +280,7 @@ class SalesOrderLines extends React.Component {
                 <td>No</td>
                 <td>Item Id</td>
                 <td>Item Name</td>
-                <td>Measurement</td>
+                                <td>Unit</td>
                 <td>Quantity</td>
                 <td>Amount</td>
                 <td>Discount</td>


### PR DESCRIPTION
Updates client-facing frontend language across the app by replacing the term Measurement with Unit where it appears in visible UI text.

Changes:
Updated visible table headers from Measurement to Unit
Updated dropdown placeholders like -- Select Measurement -- to -- Select Unit --
Updated item/inventory labels such as Smallest Measurement and Purchase Measurement to Smallest Unit and Purchase Unit
Updated one user-facing validation/error message to say Unit instead of Measurement

