### PR TITLE
#217 Implement dashboard features with DTO, service, and API

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <RepositoryType>git</RepositoryType>
     <DebugType>embedded</DebugType>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);NU5105</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU1903</NoWarn>
 
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <GenerateFullPaths Condition="'$(VSCODE_PID)' != ''">true</GenerateFullPaths>

--- a/src/AccountGoWeb/AccountGoWeb.csproj
+++ b/src/AccountGoWeb/AccountGoWeb.csproj
@@ -18,7 +18,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <!-- <ProjectReference Include="../Dto/Dto.csproj" /> -->
+    <ProjectReference Include="../Dto/Dto.csproj" />
     <!-- <ProjectReference Include="../Infrastructure/Infrastructure.csproj" /> -->
     <ProjectReference Include="../src.ServiceDefaults/src.ServiceDefaults.csproj" />
     <ProjectReference Include="../LibraryGDB/LibraryGDB.csproj" />

--- a/src/AccountGoWeb/Controllers/DashboardController.cs
+++ b/src/AccountGoWeb/Controllers/DashboardController.cs
@@ -1,13 +1,18 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Dto.Dashboard;
+using Microsoft.AspNetCore.Mvc;
+using System.Net.Http.Json;
 
 namespace AccountGoWeb.Controllers
 {
     //[Microsoft.AspNetCore.Authorization.Authorize]
     public class DashboardController : BaseController
     {
-        public DashboardController(IConfiguration config)
+        private readonly HttpClient _httpClient;
+
+        public DashboardController(IConfiguration config, HttpClient httpClient)
         {
             _baseConfig = config;
+            _httpClient = httpClient;
             Models.SelectListItemHelper._config = config;
         }
         // GET: /<controller>/
@@ -16,10 +21,23 @@ namespace AccountGoWeb.Controllers
             return View();
         }
 
-        public IActionResult MonthlySales()
+        public async Task<IActionResult> MonthlySales()
         {
-            ViewBag.ApiMontlySales = _baseConfig!["ApiUrl"] + "sales/getmonthlysales";
-            return View();
+            ViewBag.PageContentHeader = "Dashboard";
+
+            DashboardSummaryDto model;
+
+            try
+            {
+                model = await _httpClient.GetFromJsonAsync<DashboardSummaryDto>("dashboard/summary")
+                    ?? new DashboardSummaryDto();
+            }
+            catch
+            {
+                model = new DashboardSummaryDto();
+            }
+
+            return View(model);
         }
     }
 }

--- a/src/AccountGoWeb/Controllers/HomeController.cs
+++ b/src/AccountGoWeb/Controllers/HomeController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace AccountGoWeb.Controllers
 {

--- a/src/AccountGoWeb/Views/Dashboard/MonthlySales.cshtml
+++ b/src/AccountGoWeb/Views/Dashboard/MonthlySales.cshtml
@@ -1,97 +1,218 @@
-﻿
-<canvas width="500" height="250"></canvas>
+@model Dto.Dashboard.DashboardSummaryDto
+@using System.Globalization
+@using Dto.Dashboard
+@inject IConfiguration _configuration
+@{
+    var dashboard = Model ?? new DashboardSummaryDto();
+    var monthlySales = dashboard.MonthlySales ?? new List<DashboardTrendPointDto>();
+    var monthlyExpenses = dashboard.MonthlyExpenses ?? new List<DashboardTrendPointDto>();
+    var salesMax = monthlySales.Any() ? monthlySales.Max(x => x.Amount) : 0m;
+    var expensesMax = monthlyExpenses.Any() ? monthlyExpenses.Max(x => x.Amount) : 0m;
+    var receivables = dashboard.TopReceivables ?? new List<DashboardReceivableItemDto>();
+    var payables = dashboard.UpcomingPayables ?? new List<DashboardPayableItemDto>();
+    var activity = dashboard.RecentActivity ?? new List<DashboardActivityItemDto>();
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
+    string Currency(decimal amount) => string.Format(CultureInfo.InvariantCulture, "${0:N2}", amount);
+}
 
-    <script>
-     var canvas = document.querySelector("canvas"),
-         context = canvas.getContext("2d");
+@section Styles {
+    <link rel="stylesheet" href="~/css/dashboard.css" asp-append-version="true" />
+}
 
-     var margin = { top: 20, right: 20, bottom: 30, left: 40 },
-         width = canvas.width - margin.left - margin.right,
-         height = canvas.height - margin.top - margin.bottom;
+<div class="dashboard-shell">
+    <div class="dashboard-topbar">
+        <div class="dashboard-heading">
+            <p>Year-to-date accounting snapshot for @_configuration["GoodDeeds:SuperOrganizationName"]</p>
+        </div>
+        <div class="dashboard-period">Year to Date</div>
+    </div>
 
-     var x = d3.scaleBand()
-         .rangeRound([0, width])
-         .padding(0.1);
+    <section class="dashboard-card">
+        <div class="dashboard-card-title">Financial Health Snapshot</div>
+        <div class="dashboard-card-subtitle">Core year-to-date totals for the most important accounting indicators.</div>
+        <div class="dashboard-kpis">
+            <div class="kpi-card">
+                <div class="kpi-label">Money in Bank</div>
+                <div class="kpi-value">@Currency(dashboard.Kpis.MoneyInBank)</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-label">Receivables</div>
+                <div class="kpi-value">@Currency(dashboard.Kpis.OutstandingReceivables)</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-label">Payables</div>
+                <div class="kpi-value">@Currency(dashboard.Kpis.TotalPayables)</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-label">Assets</div>
+                <div class="kpi-value">@Currency(dashboard.Kpis.TotalAssets)</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-label">Sales YTD</div>
+                <div class="kpi-value">@Currency(dashboard.Kpis.TotalSalesYtd)</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-label">Expenses YTD</div>
+                <div class="kpi-value">@Currency(dashboard.Kpis.TotalExpensesYtd)</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-label">Net Profit</div>
+                <div class="kpi-value">@Currency(dashboard.Kpis.NetProfitYtd)</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-label">Cash Flow YTD</div>
+                <div class="kpi-value">@Currency(dashboard.Kpis.CashFlowYtd)</div>
+            </div>
+        </div>
+    </section>
 
-     var y = d3.scaleLinear()
-         .rangeRound([height, 0]);
+    <div class="dashboard-grid">
+        <section class="dashboard-card">
+            <div class="dashboard-card-title">Monthly Performance</div>
+            <div class="dashboard-card-subtitle">Sales and expense movement over the current year.</div>
 
-     context.translate(margin.left, margin.top);
+            @if (!monthlySales.Any() && !monthlyExpenses.Any())
+            {
+                <p class="empty-state">No monthly trend data is available yet.</p>
+            }
+            else
+            {
+                <div class="trend-chart">
+                    @for (var i = 0; i < Math.Max(monthlySales.Count, monthlyExpenses.Count); i++)
+                    {
+                        var salesPoint = i < monthlySales.Count ? monthlySales[i] : new DashboardTrendPointDto();
+                        var expensePoint = i < monthlyExpenses.Count ? monthlyExpenses[i] : new DashboardTrendPointDto { Label = salesPoint.Label };
+                        var salesHeight = salesMax > 0 ? Math.Max(6, (int)Math.Round((salesPoint.Amount / salesMax) * 100m)) : 0;
+                        var expenseHeight = expensesMax > 0 ? Math.Max(6, (int)Math.Round((expensePoint.Amount / expensesMax) * 100m)) : 0;
 
-     d3.json("@ViewBag.ApiMontlySales", function (data) {
+                        <div class="trend-col">
+                            <div class="trend-bars">
+                                <div class="trend-sales" style="height:@($"{salesHeight}%")" title="Sales: @Currency(salesPoint.Amount)"></div>
+                                <div class="trend-expenses" style="height:@($"{expenseHeight}%")" title="Expenses: @Currency(expensePoint.Amount)"></div>
+                            </div>
+                            <div class="trend-label">@(salesPoint.Label ?? expensePoint.Label)</div>
+                        </div>
+                    }
+                </div>
+            }
+        </section>
 
-         data.forEach(function (d) {
-             d.month = d.month;
-             d.amount = +d.amount;
-         });
+        <section class="dashboard-card">
+            <div class="dashboard-card-title">Asset / Liability Snapshot</div>
+            <div class="dashboard-card-subtitle">Current balance sheet totals for the main account classes.</div>
 
+            @{
+                var snapshotMax = new[]
+                {
+                    dashboard.BalanceSnapshot.TotalAssets,
+                    dashboard.BalanceSnapshot.TotalLiabilities,
+                    dashboard.BalanceSnapshot.TotalEquity
+                }.Max();
+            }
 
-         x.domain(data.map(function (d) { return d.month; }));
-         y.domain([0, d3.max(data, function (d) { return d.amount; })]);
+            <div class="snapshot-list">
+                <div class="snapshot-row">
+                    <div class="snapshot-row-header">
+                        <span>Assets</span>
+                        <span>@Currency(dashboard.BalanceSnapshot.TotalAssets)</span>
+                    </div>
+                    <div class="snapshot-track">
+                        <div class="snapshot-fill fill-assets" style="width:@(snapshotMax > 0 ? (dashboard.BalanceSnapshot.TotalAssets / snapshotMax * 100m).ToString("0.##", CultureInfo.InvariantCulture) : "0")%;"></div>
+                    </div>
+                </div>
+                <div class="snapshot-row">
+                    <div class="snapshot-row-header">
+                        <span>Liabilities</span>
+                        <span>@Currency(dashboard.BalanceSnapshot.TotalLiabilities)</span>
+                    </div>
+                    <div class="snapshot-track">
+                        <div class="snapshot-fill fill-liabilities" style="width:@(snapshotMax > 0 ? (dashboard.BalanceSnapshot.TotalLiabilities / snapshotMax * 100m).ToString("0.##", CultureInfo.InvariantCulture) : "0")%;"></div>
+                    </div>
+                </div>
+                <div class="snapshot-row">
+                    <div class="snapshot-row-header">
+                        <span>Equity</span>
+                        <span>@Currency(dashboard.BalanceSnapshot.TotalEquity)</span>
+                    </div>
+                    <div class="snapshot-track">
+                        <div class="snapshot-fill fill-equity" style="width:@(snapshotMax > 0 ? (dashboard.BalanceSnapshot.TotalEquity / snapshotMax * 100m).ToString("0.##", CultureInfo.InvariantCulture) : "0")%;"></div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
 
-         var yTickCount = 10,
-             yTicks = y.ticks(yTickCount),
-             yTickFormat = y.tickFormat(yTickCount, "%");
-         console.log(yTickFormat);
-         context.beginPath();
-         x.domain().forEach(function (d) {
-             context.moveTo(x(d) + x.bandwidth() / 2, height);
-             context.lineTo(x(d) + x.bandwidth() / 2, height + 6);
-         });
-         context.strokeStyle = "black";
-         context.stroke();
+    <div class="dashboard-lists">
+        <section class="dashboard-card">
+            <div class="dashboard-card-title">Outstanding Receivables</div>
+            <div class="dashboard-card-subtitle">Customers with the highest outstanding balances.</div>
+            @if (!receivables.Any())
+            {
+                <p class="empty-state">No receivables are currently outstanding.</p>
+            }
+            else
+            {
+                <ul class="dashboard-list">
+                    @foreach (var item in receivables)
+                    {
+                        <li>
+                            <div>
+                                <div class="list-title">@item.CustomerName</div>
+                                <span class="list-meta">Customer ID: @item.CustomerId</span>
+                            </div>
+                            <div class="list-value">@Currency(item.Balance)</div>
+                        </li>
+                    }
+                </ul>
+            }
+        </section>
 
-         context.textAlign = "center";
-         context.textBaseline = "top";
-         x.domain().forEach(function (d) {
-             context.fillText(d, x(d) + x.bandwidth() / 2, height + 6);
-         });
+        <section class="dashboard-card">
+            <div class="dashboard-card-title">Upcoming Payables</div>
+            <div class="dashboard-card-subtitle">Open vendor invoices that still require payment.</div>
+            @if (!payables.Any())
+            {
+                <p class="empty-state">There are no unpaid purchase invoices right now.</p>
+            }
+            else
+            {
+                <ul class="dashboard-list">
+                    @foreach (var item in payables)
+                    {
+                        <li>
+                            <div>
+                                <div class="list-title">@item.VendorName</div>
+                                <span class="list-meta">@item.InvoiceNo @(item.InvoiceDate.HasValue ? $"- {item.InvoiceDate.Value:yyyy-MM-dd}" : string.Empty)</span>
+                            </div>
+                            <div class="list-value">@Currency(item.RemainingAmount)</div>
+                        </li>
+                    }
+                </ul>
+            }
+        </section>
+    </div>
 
-         context.beginPath();
-         yTicks.forEach(function (d) {
-             context.moveTo(0, y(d) + 0.5);
-             context.lineTo(-6, y(d) + 0.5);
-         });
-         context.strokeStyle = "black";
-         context.stroke();
-
-         context.textAlign = "right";
-         context.textBaseline = "middle";
-         yTicks.forEach(function (d) {
-             //context.fillText(yTickFormat(d), -9, y(d));
-             context.fillText(d, -9, y(d));
-         });
-
-         context.beginPath();
-         context.moveTo(-6.5, 0 + 0.5);
-         context.lineTo(0.5, 0 + 0.5);
-         context.lineTo(0.5, height + 0.5);
-         context.lineTo(-6.5, height + 0.5);
-         context.strokeStyle = "black";
-         context.stroke();
-
-         context.save();
-         context.rotate(-Math.PI / 2);
-         context.textAlign = "right";
-         context.textBaseline = "top";
-         context.font = "bold 10px sans-serif";
-         context.fillText("amount", -10, 10);
-         context.restore();
-         context.strokeStyle = "black";
-         context.stroke();
-         context.fillStyle = "steelblue";
-         context.strokeStyle = "black";
-         context.stroke();
-         context.font = "bold 13px sans-serif";
-         context.fillText("Monthly Sales", 250, canvas.height - 260);
-
-         data.forEach(function (d) {
-             context.fillText(d.amount, x(d.month) + 35, y(d.amount) - 10, height - y(d.amount));
-             context.fillRect(x(d.month), y(d.amount), x.bandwidth(), height - y(d.amount));
-             context.font = "bold 10px arial";
-         });
-     });
-
-    </script>
+    <section class="dashboard-card">
+        <div class="dashboard-card-title">Recent Activity</div>
+        <div class="dashboard-card-subtitle">Latest financial transactions and documents recorded in the system.</div>
+        @if (!activity.Any())
+        {
+            <p class="empty-state">No recent activity is available.</p>
+        }
+        else
+        {
+            <ul class="dashboard-activity">
+                @foreach (var item in activity)
+                {
+                    <li>
+                        <div>
+                            <span class="activity-type">@item.Type</span>
+                            <div class="list-title">@item.Description</div>
+                        </div>
+                        <div class="list-meta">@item.Date.ToString("yyyy-MM-dd")</div>
+                    </li>
+                }
+            </ul>
+        }
+    </section>
+</div>

--- a/src/AccountGoWeb/Views/Home/Index.cshtml
+++ b/src/AccountGoWeb/Views/Home/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@inject IConfiguration _configuration
+@inject IConfiguration _configuration
 <div class="row">
     <div class="col-md-12">
         <img src="~/images/gbd/logo2_trans.png" alt="Good Deed Books Logo" class="img-fluid mx-auto d-block" id="main-logo" style="width: 50%;" />

--- a/src/AccountGoWeb/Views/Shared/_Layout_bootstrap.cshtml
+++ b/src/AccountGoWeb/Views/Shared/_Layout_bootstrap.cshtml
@@ -24,6 +24,7 @@
     <link href="https://cdn.jsdelivr.net/npm/pace-js@latest/pace-theme-default.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/styles/ag-grid.css">
     <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/styles/ag-theme-alpine.css">
+    @RenderSection("Styles", required: false)
 
 </head>
 

--- a/src/AccountGoWeb/wwwroot/css/dashboard.css
+++ b/src/AccountGoWeb/wwwroot/css/dashboard.css
@@ -1,0 +1,277 @@
+.dashboard-shell {
+    color: #f4f7fb;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding-bottom: 2rem;
+}
+
+.dashboard-topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.dashboard-heading h3 {
+    margin: 0;
+    color: #fff;
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.dashboard-heading p {
+    margin: 0.35rem 0 0;
+    color: #9fb2c9;
+}
+
+.dashboard-period {
+    background: #13233b;
+    border: 1px solid #2b466b;
+    border-radius: 999px;
+    color: #dce8f6;
+    padding: 0.55rem 1rem;
+    font-weight: 600;
+}
+
+.dashboard-card {
+    background: linear-gradient(180deg, rgba(19, 33, 54, 0.96), rgba(11, 20, 35, 0.98));
+    border: 1px solid rgba(82, 118, 165, 0.35);
+    border-radius: 18px;
+    box-shadow: 0 18px 32px rgba(0, 0, 0, 0.28);
+    padding: 1.25rem;
+}
+
+.dashboard-card-title {
+    color: #fff;
+    font-size: 1.1rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+
+.dashboard-card-subtitle {
+    color: #91a7c3;
+    font-size: 0.92rem;
+    margin-bottom: 1rem;
+}
+
+.dashboard-kpis {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.kpi-card {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(111, 146, 194, 0.18);
+    border-radius: 16px;
+    padding: 1rem;
+    min-height: 112px;
+}
+
+.kpi-label {
+    color: #89a1c0;
+    font-size: 0.82rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.kpi-value {
+    color: #fff;
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-top: 0.6rem;
+    word-break: break-word;
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 1.5rem;
+}
+
+.trend-chart {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 0.6rem;
+    align-items: end;
+    min-height: 270px;
+    margin-top: 1rem;
+}
+
+.trend-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: end;
+    gap: 0.45rem;
+    height: 100%;
+}
+
+.trend-bars {
+    display: flex;
+    align-items: end;
+    gap: 0.18rem;
+    height: 200px;
+    width: 100%;
+    justify-content: center;
+}
+
+.trend-sales,
+.trend-expenses {
+    width: 14px;
+    border-radius: 8px 8px 4px 4px;
+}
+
+.trend-sales {
+    background: linear-gradient(180deg, #5fd0ff, #2f7df4);
+}
+
+.trend-expenses {
+    background: linear-gradient(180deg, #f9c46b, #f08a32);
+}
+
+.trend-label {
+    color: #8da4c2;
+    font-size: 0.78rem;
+}
+
+.snapshot-list {
+    display: grid;
+    gap: 0.9rem;
+}
+
+.snapshot-row {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(111, 146, 194, 0.18);
+    border-radius: 14px;
+    padding: 0.9rem 1rem;
+}
+
+.snapshot-row-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.55rem;
+    color: #dce7f7;
+    font-weight: 600;
+}
+
+.snapshot-track {
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+}
+
+.snapshot-fill {
+    height: 100%;
+    border-radius: 999px;
+}
+
+.fill-assets { background: #54c3ff; }
+.fill-liabilities { background: #f6a04d; }
+.fill-equity { background: #5ad28c; }
+
+.dashboard-lists {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem;
+}
+
+.dashboard-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.8rem;
+}
+
+.dashboard-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(111, 146, 194, 0.18);
+    border-radius: 14px;
+    padding: 0.9rem 1rem;
+}
+
+.list-title {
+    color: #fff;
+    font-weight: 600;
+}
+
+.list-meta {
+    display: block;
+    color: #90a7c5;
+    font-size: 0.85rem;
+    margin-top: 0.15rem;
+}
+
+.list-value {
+    color: #fff;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.dashboard-activity {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.dashboard-activity li {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1rem;
+    border-bottom: 1px solid rgba(111, 146, 194, 0.14);
+    padding-bottom: 0.75rem;
+}
+
+.dashboard-activity li:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+
+.activity-type {
+    display: inline-block;
+    border-radius: 999px;
+    background: rgba(95, 208, 255, 0.14);
+    color: #7cd7ff;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    padding: 0.22rem 0.55rem;
+    margin-bottom: 0.35rem;
+}
+
+.empty-state {
+    color: #8fa5c1;
+    font-style: italic;
+    margin: 0;
+}
+
+@media (max-width: 1200px) {
+    .dashboard-kpis {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 992px) {
+    .dashboard-grid,
+    .dashboard-lists {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 576px) {
+    .dashboard-kpis {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/Api/Controllers/DashboardController.cs
+++ b/src/Api/Controllers/DashboardController.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Mvc;
+using Services.Dashboard;
+
+namespace Api.Controllers
+{
+    [Route("api/[controller]")]
+    public class DashboardController : BaseController
+    {
+        private readonly IDashboardService _dashboardService;
+
+        public DashboardController(IDashboardService dashboardService)
+        {
+            _dashboardService = dashboardService;
+        }
+
+        [HttpGet]
+        [Route("Summary")]
+        public IActionResult Summary(
+            DateTime? from = null,
+            DateTime? to = null,
+            int topReceivables = 5,
+            int topPayables = 5,
+            int recentActivity = 5)
+        {
+            var summary = _dashboardService.GetDashboardSummary(
+                from,
+                to,
+                topReceivables,
+                topPayables,
+                recentActivity);
+
+            return Ok(summary);
+        }
+    }
+}

--- a/src/Api/Data/Initializer.cs
+++ b/src/Api/Data/Initializer.cs
@@ -7,6 +7,7 @@ using Services.Sales;
 using Services.Security;
 using System.Reflection;
 using System.Text;
+using Core.Domain.Items;
 
 namespace Api.Data
 {
@@ -94,6 +95,10 @@ namespace Api.Data
                 //11.Security Roles
                 SetupSecurityRoles();
                 Console.WriteLine("SetupSecurityRoles() - Completed!");
+
+                //12.Dashboard demo data
+                SetupDashboardDemoData();
+                Console.WriteLine("SetupDashboardDemoData() - Completed!");
 
                 return true;
             }
@@ -902,6 +907,243 @@ namespace Api.Data
                 Console.WriteLine(ex.Message + " - " + ex.StackTrace);
                 throw;
             }
+        }
+
+        private void SetupDashboardDemoData()
+        {
+            if (_salesService.GetSalesInvoices().Any()
+                || _salesService.GetSalesReceipts().Any()
+                || _purchasingService.GetPurchaseInvoices().Any())
+            {
+                return;
+            }
+
+            var today = DateTime.Today;
+            var currentYearStart = new DateTime(today.Year, 1, 1);
+
+            var bank = _financialService.GetCashAndBanks().FirstOrDefault(b => b.AccountId.HasValue);
+            var purchasedItem = _inventoryService.GetAllItems()
+                .FirstOrDefault(i => i.ItemCategory != null && i.ItemCategory.ItemType == Core.Domain.ItemTypes.Purchased);
+            var paymentTermId = _adminService.GetPaymentTerms().FirstOrDefault()?.Id;
+
+            if (bank?.AccountId == null || purchasedItem == null)
+            {
+                return;
+            }
+
+            var customers = _salesService.GetCustomers().ToList();
+            var vendors = _purchasingService.GetVendors().ToList();
+
+            var primaryCustomer = customers.FirstOrDefault() ?? CreateDemoCustomer("ABC Customer");
+            var secondaryCustomer = customers.Skip(1).FirstOrDefault() ?? CreateDemoCustomer("Northwind Books");
+            var primaryVendor = vendors.FirstOrDefault() ?? CreateDemoVendor("ABC Sample Supplier");
+            var secondaryVendor = vendors.Skip(1).FirstOrDefault() ?? CreateDemoVendor("Paper & Parcel Co.");
+
+            SeedSalesInvoice(
+                primaryCustomer,
+                purchasedItem,
+                currentYearStart.AddMonths(1).AddDays(4),
+                paymentTermId,
+                6,
+                purchasedItem.Price ?? 95m);
+
+            var unpaidSalesInvoice = SeedSalesInvoice(
+                secondaryCustomer,
+                purchasedItem,
+                currentYearStart.AddMonths(2).AddDays(9),
+                paymentTermId,
+                4,
+                (purchasedItem.Price ?? 95m) + 20m);
+
+            SeedCustomerReceipt(
+                primaryCustomer,
+                bank.AccountId.Value,
+                currentYearStart.AddMonths(1).AddDays(18),
+                300m);
+
+            SeedPurchaseInvoice(
+                primaryVendor,
+                purchasedItem,
+                currentYearStart.AddMonths(1).AddDays(2),
+                paymentTermId,
+                10,
+                purchasedItem.Cost ?? 40m);
+
+            var payableInvoice = SeedPurchaseInvoice(
+                secondaryVendor,
+                purchasedItem,
+                currentYearStart.AddMonths(3).AddDays(3),
+                paymentTermId,
+                8,
+                (purchasedItem.Cost ?? 40m) + 8m);
+
+            SeedVendorPayment(
+                payableInvoice,
+                secondaryVendor,
+                bank.AccountId.Value,
+                currentYearStart.AddMonths(3).AddDays(15),
+                150m);
+        }
+
+        private Core.Domain.Sales.Customer CreateDemoCustomer(string name)
+        {
+            var customer = new Core.Domain.Sales.Customer
+            {
+                AccountsReceivableAccountId = _financialService.GetAccountByAccountCode("10120").Id,
+                SalesAccountId = _financialService.GetAccountByAccountCode("40100").Id,
+                CustomerAdvancesAccountId = _financialService.GetAccountByAccountCode("20120").Id,
+                SalesDiscountAccountId = _financialService.GetAccountByAccountCode("40400").Id,
+                TaxGroupId = _financialService.GetTaxGroups().FirstOrDefault(tg => tg.Description == "VAT")?.Id,
+                Party = new Core.Domain.Party
+                {
+                    Name = name,
+                    PartyType = Core.Domain.PartyTypes.Customer,
+                    IsActive = true
+                },
+                PrimaryContact = new Core.Domain.Contact
+                {
+                    ContactType = Core.Domain.ContactTypes.Customer,
+                    FirstName = name.Split(' ').First(),
+                    LastName = "Contact",
+                    Party = new Core.Domain.Party
+                    {
+                        Name = $"{name} Contact",
+                        PartyType = Core.Domain.PartyTypes.Contact
+                    }
+                }
+            };
+
+            _salesService.AddCustomer(customer);
+            return customer;
+        }
+
+        private Core.Domain.Purchases.Vendor CreateDemoVendor(string name)
+        {
+            var vendor = new Core.Domain.Purchases.Vendor
+            {
+                AccountsPayableAccountId = _financialService.GetAccountByAccountCode("20110").Id,
+                PurchaseAccountId = _financialService.GetAccountByAccountCode("50200").Id,
+                PurchaseDiscountAccountId = _financialService.GetAccountByAccountCode("50400").Id,
+                Party = new Core.Domain.Party
+                {
+                    Name = name,
+                    PartyType = Core.Domain.PartyTypes.Vendor,
+                    IsActive = true
+                },
+                PrimaryContact = new Core.Domain.Contact
+                {
+                    ContactType = Core.Domain.ContactTypes.Vendor,
+                    FirstName = name.Split(' ').First(),
+                    LastName = "Contact",
+                    Party = new Core.Domain.Party
+                    {
+                        Name = $"{name} Contact",
+                        PartyType = Core.Domain.PartyTypes.Contact
+                    }
+                }
+            };
+
+            _purchasingService.AddVendor(vendor);
+            return vendor;
+        }
+
+        private Core.Domain.Sales.SalesInvoiceHeader SeedSalesInvoice(
+            Core.Domain.Sales.Customer customer,
+            Item item,
+            DateTime invoiceDate,
+            int? paymentTermId,
+            decimal quantity,
+            decimal amount)
+        {
+            var measurementId = item.SellMeasurementId ?? item.SmallestMeasurementId ?? _inventoryService.GetMeasurements().First().Id;
+
+            var invoice = new Core.Domain.Sales.SalesInvoiceHeader
+            {
+                CustomerId = customer.Id,
+                Date = invoiceDate,
+                PaymentTermId = paymentTermId,
+                ReferenceNo = $"DASH-SI-{invoiceDate:MMdd}"
+            };
+
+            invoice.SalesInvoiceLines.Add(new Core.Domain.Sales.SalesInvoiceLine
+            {
+                ItemId = item.Id,
+                MeasurementId = measurementId,
+                Quantity = quantity,
+                Discount = 0m,
+                Amount = amount
+            });
+
+            _salesService.AddSalesInvoice(invoice, null, null);
+            return invoice;
+        }
+
+        private void SeedCustomerReceipt(
+            Core.Domain.Sales.Customer customer,
+            int bankAccountId,
+            DateTime receiptDate,
+            decimal amountPaid)
+        {
+            var receipt = new Core.Domain.Sales.SalesReceiptHeader
+            {
+                CustomerId = customer.Id,
+                Date = receiptDate,
+                AccountToDebitId = bankAccountId,
+                Amount = amountPaid
+            };
+
+            receipt.SalesReceiptLines.Add(new Core.Domain.Sales.SalesReceiptLine
+            {
+                Quantity = 1,
+                Amount = amountPaid,
+                AmountPaid = amountPaid
+            });
+
+            _salesService.AddSalesReceipt(receipt);
+        }
+
+        private Core.Domain.Purchases.PurchaseInvoiceHeader SeedPurchaseInvoice(
+            Core.Domain.Purchases.Vendor vendor,
+            Item item,
+            DateTime invoiceDate,
+            int? paymentTermId,
+            decimal quantity,
+            decimal amount)
+        {
+            var measurementId = item.PurchaseMeasurementId ?? item.SmallestMeasurementId ?? _inventoryService.GetMeasurements().First().Id;
+
+            var invoice = new Core.Domain.Purchases.PurchaseInvoiceHeader
+            {
+                VendorId = vendor.Id,
+                Date = invoiceDate,
+                VendorInvoiceNo = $"V-{invoiceDate:MMdd}",
+                ReferenceNo = $"DASH-PI-{invoiceDate:MMdd}",
+                PaymentTermId = paymentTermId,
+                Description = "Dashboard demo purchase invoice"
+            };
+
+            invoice.PurchaseInvoiceLines.Add(new Core.Domain.Purchases.PurchaseInvoiceLine
+            {
+                ItemId = item.Id,
+                MeasurementId = measurementId,
+                Quantity = quantity,
+                Cost = amount,
+                Discount = 0m,
+                Amount = amount
+            });
+
+            _purchasingService.AddPurchaseInvoice(invoice, null);
+            return invoice;
+        }
+
+        private void SeedVendorPayment(
+            Core.Domain.Purchases.PurchaseInvoiceHeader invoice,
+            Core.Domain.Purchases.Vendor vendor,
+            int bankAccountId,
+            DateTime paymentDate,
+            decimal amount)
+        {
+            _purchasingService.SavePayment(invoice.Id, vendor.Id, bankAccountId, amount, paymentDate);
         }
 
         private static string[,] LoadCsv(string filename)

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -54,6 +54,7 @@ builder.Services.AddScoped(typeof(Core.Data.ISecurityRepository), typeof(Securit
 // domain services
 builder.Services.AddScoped(typeof(Services.Sales.ISalesService), typeof(Services.Sales.SalesService));
 builder.Services.AddScoped(typeof(Services.Donations.IDonationsService), typeof(Services.Donations.DonationsService));
+builder.Services.AddScoped(typeof(Services.Dashboard.IDashboardService), typeof(Services.Dashboard.DashboardService));
 builder.Services.AddScoped(typeof(Services.Financial.IFinancialService), typeof(Services.Financial.FinancialService));
 builder.Services.AddScoped(typeof(Services.Inventory.IInventoryService), typeof(Services.Inventory.InventoryService));
 builder.Services.AddScoped(typeof(Services.Purchasing.IPurchasingService), typeof(Services.Purchasing.PurchasingService));

--- a/src/Dto/Dashboard/DashboardActivityItemDto.cs
+++ b/src/Dto/Dashboard/DashboardActivityItemDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Dto.Dashboard
+{
+    public class DashboardActivityItemDto
+    {
+        public string Type { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public DateTime Date { get; set; }
+    }
+}

--- a/src/Dto/Dashboard/DashboardBalanceSnapshotDto.cs
+++ b/src/Dto/Dashboard/DashboardBalanceSnapshotDto.cs
@@ -1,0 +1,9 @@
+namespace Dto.Dashboard
+{
+    public class DashboardBalanceSnapshotDto
+    {
+        public decimal TotalAssets { get; set; }
+        public decimal TotalLiabilities { get; set; }
+        public decimal TotalEquity { get; set; }
+    }
+}

--- a/src/Dto/Dashboard/DashboardKpiDto.cs
+++ b/src/Dto/Dashboard/DashboardKpiDto.cs
@@ -1,0 +1,14 @@
+namespace Dto.Dashboard
+{
+    public class DashboardKpiDto
+    {
+        public decimal MoneyInBank { get; set; }
+        public decimal OutstandingReceivables { get; set; }
+        public decimal TotalPayables { get; set; }
+        public decimal TotalAssets { get; set; }
+        public decimal TotalSalesYtd { get; set; }
+        public decimal TotalExpensesYtd { get; set; }
+        public decimal NetProfitYtd { get; set; }
+        public decimal CashFlowYtd { get; set; }
+    }
+}

--- a/src/Dto/Dashboard/DashboardPayableItemDto.cs
+++ b/src/Dto/Dashboard/DashboardPayableItemDto.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Dto.Dashboard
+{
+    public class DashboardPayableItemDto
+    {
+        public int PurchaseInvoiceId { get; set; }
+        public string VendorName { get; set; } = string.Empty;
+        public string InvoiceNo { get; set; } = string.Empty;
+        public decimal RemainingAmount { get; set; }
+        public DateTime? InvoiceDate { get; set; }
+    }
+}

--- a/src/Dto/Dashboard/DashboardReceivableItemDto.cs
+++ b/src/Dto/Dashboard/DashboardReceivableItemDto.cs
@@ -1,0 +1,9 @@
+namespace Dto.Dashboard
+{
+    public class DashboardReceivableItemDto
+    {
+        public int CustomerId { get; set; }
+        public string CustomerName { get; set; } = string.Empty;
+        public decimal Balance { get; set; }
+    }
+}

--- a/src/Dto/Dashboard/DashboardSummaryDto.cs
+++ b/src/Dto/Dashboard/DashboardSummaryDto.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Dto.Dashboard
+{
+    public class DashboardSummaryDto
+    {
+        public DashboardKpiDto Kpis { get; set; } = new();
+        public DashboardBalanceSnapshotDto BalanceSnapshot { get; set; } = new();
+        public List<DashboardTrendPointDto> MonthlySales { get; set; } = new();
+        public List<DashboardTrendPointDto> MonthlyExpenses { get; set; } = new();
+        public List<DashboardReceivableItemDto> TopReceivables { get; set; } = new();
+        public List<DashboardPayableItemDto> UpcomingPayables { get; set; } = new();
+        public List<DashboardActivityItemDto> RecentActivity { get; set; } = new();
+    }
+}

--- a/src/Dto/Dashboard/DashboardTrendPointDto.cs
+++ b/src/Dto/Dashboard/DashboardTrendPointDto.cs
@@ -1,0 +1,8 @@
+namespace Dto.Dashboard
+{
+    public class DashboardTrendPointDto
+    {
+        public string Label { get; set; } = string.Empty;
+        public decimal Amount { get; set; }
+    }
+}

--- a/src/MigrationService/MigrationService.csproj
+++ b/src/MigrationService/MigrationService.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.0.1" />
+    <PackageReference Include="Aspire.Microsoft.EntityFrameworkCore.SqlServer" Version="13.2.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
   </ItemGroup>
 

--- a/src/Services/Dashboard/DashboardService.cs
+++ b/src/Services/Dashboard/DashboardService.cs
@@ -1,0 +1,242 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Core.Domain;
+using Dto.Dashboard;
+using Services.Financial;
+using Services.Purchasing;
+using Services.Sales;
+
+namespace Services.Dashboard
+{
+    public class DashboardService : IDashboardService
+    {
+        private readonly IFinancialService _financialService;
+        private readonly ISalesService _salesService;
+        private readonly IPurchasingService _purchasingService;
+
+        public DashboardService(
+            IFinancialService financialService,
+            ISalesService salesService,
+            IPurchasingService purchasingService)
+        {
+            _financialService = financialService;
+            _salesService = salesService;
+            _purchasingService = purchasingService;
+        }
+
+        public DashboardSummaryDto GetDashboardSummary(
+            DateTime? from = null,
+            DateTime? to = null,
+            int topReceivables = 5,
+            int topPayables = 5,
+            int recentActivity = 5)
+        {
+            var (rangeStart, rangeEnd) = ResolveDateRange(from, to);
+
+            var accounts = _financialService.GetAccounts().ToList();
+            var ledger = _financialService.MasterGeneralLedger(rangeStart, rangeEnd).ToList();
+            var balanceSheet = _financialService.BalanceSheet().ToList();
+            var customers = _salesService.GetCustomers().ToList();
+            var vendors = _purchasingService.GetVendors().ToList();
+            var salesInvoices = _salesService.GetSalesInvoices().ToList();
+            var salesReceipts = _salesService.GetSalesReceipts().ToList();
+            var purchaseInvoices = _purchasingService.GetPurchaseInvoices().ToList();
+
+            var revenueAccountIds = accounts
+                .Where(a => a.AccountClassId == (int)AccountClasses.Revenue)
+                .Select(a => a.Id)
+                .ToHashSet();
+
+            var expenseAccountIds = accounts
+                .Where(a => a.AccountClassId == (int)AccountClasses.Expense)
+                .Select(a => a.Id)
+                .ToHashSet();
+
+            var bankAccountIds = _financialService.GetCashAndBanks()
+                .Where(b => b.AccountId.HasValue)
+                .Select(b => b.AccountId!.Value)
+                .Distinct()
+                .ToHashSet();
+
+            var totalSalesYtd = ComputeNetAmount(ledger, revenueAccountIds, normalBalanceIsDebit: false);
+            var totalExpensesYtd = ComputeNetAmount(ledger, expenseAccountIds, normalBalanceIsDebit: true);
+            var cashFlowYtd = ComputeNetAmount(ledger, bankAccountIds, normalBalanceIsDebit: true);
+
+            var summary = new DashboardSummaryDto
+            {
+                Kpis = new DashboardKpiDto
+                {
+                    MoneyInBank = bankAccountIds.Sum(accountId => _financialService.GetAccount(accountId)?.Balance ?? 0m),
+                    OutstandingReceivables = customers.Sum(c => c.Balance),
+                    TotalPayables = vendors.Sum(v => v.GetBalance()),
+                    TotalAssets = balanceSheet
+                        .Where(item => item.AccountClassId == (int)AccountClasses.Assets)
+                        .Sum(item => item.Amount),
+                    TotalSalesYtd = totalSalesYtd,
+                    TotalExpensesYtd = totalExpensesYtd,
+                    NetProfitYtd = totalSalesYtd - totalExpensesYtd,
+                    CashFlowYtd = cashFlowYtd
+                },
+                BalanceSnapshot = new DashboardBalanceSnapshotDto
+                {
+                    TotalAssets = balanceSheet
+                        .Where(item => item.AccountClassId == (int)AccountClasses.Assets)
+                        .Sum(item => item.Amount),
+                    TotalLiabilities = balanceSheet
+                        .Where(item => item.AccountClassId == (int)AccountClasses.Liabilities)
+                        .Sum(item => item.Amount),
+                    TotalEquity = balanceSheet
+                        .Where(item => item.AccountClassId == (int)AccountClasses.Equity)
+                        .Sum(item => item.Amount)
+                },
+                MonthlySales = BuildMonthlyTrend(
+                    rangeStart,
+                    rangeEnd,
+                    ledger,
+                    revenueAccountIds,
+                    normalBalanceIsDebit: false),
+                MonthlyExpenses = BuildMonthlyTrend(
+                    rangeStart,
+                    rangeEnd,
+                    ledger,
+                    expenseAccountIds,
+                    normalBalanceIsDebit: true),
+                TopReceivables = customers
+                    .Where(c => c.Balance > 0)
+                    .OrderByDescending(c => c.Balance)
+                    .Take(topReceivables)
+                    .Select(c => new DashboardReceivableItemDto
+                    {
+                        CustomerId = c.Id,
+                        CustomerName = c.Party?.Name ?? c.No ?? $"Customer {c.Id}",
+                        Balance = c.Balance
+                    })
+                    .ToList(),
+                UpcomingPayables = purchaseInvoices
+                    .Select(invoice => new
+                    {
+                        Invoice = invoice,
+                        Remaining = invoice.PurchaseInvoiceLines.Sum(line => line.Amount * line.Quantity) - invoice.AmountPaid()
+                    })
+                    .Where(x => x.Remaining > 0)
+                    .OrderBy(x => x.Invoice.Date)
+                    .Take(topPayables)
+                    .Select(x => new DashboardPayableItemDto
+                    {
+                        PurchaseInvoiceId = x.Invoice.Id,
+                        VendorName = x.Invoice.Vendor?.Party?.Name ?? $"Vendor {x.Invoice.VendorId}",
+                        InvoiceNo = x.Invoice.No ?? x.Invoice.VendorInvoiceNo ?? string.Empty,
+                        RemainingAmount = x.Remaining,
+                        InvoiceDate = x.Invoice.Date
+                    })
+                    .ToList(),
+                RecentActivity = BuildRecentActivity(
+                    salesInvoices,
+                    salesReceipts,
+                    purchaseInvoices,
+                    recentActivity)
+            };
+
+            return summary;
+        }
+
+        private static (DateTime Start, DateTime End) ResolveDateRange(DateTime? from, DateTime? to)
+        {
+            var today = DateTime.Today;
+            var start = from?.Date ?? new DateTime(today.Year, 1, 1);
+            var end = to?.Date ?? today;
+
+            if (end < start)
+            {
+                (start, end) = (end, start);
+            }
+
+            return (start, end);
+        }
+
+        private List<DashboardTrendPointDto> BuildMonthlyTrend(
+            DateTime rangeStart,
+            DateTime rangeEnd,
+            IEnumerable<MasterGeneralLedger> ledger,
+            ISet<int> accountIds,
+            bool normalBalanceIsDebit)
+        {
+            var monthlyAmounts = ledger
+                .Where(line => accountIds.Contains(line.AccountId))
+                .GroupBy(line => new { line.Date.Year, line.Date.Month })
+                .ToDictionary(
+                    group => new DateTime(group.Key.Year, group.Key.Month, 1),
+                    group => normalBalanceIsDebit
+                        ? group.Sum(item => item.Debit) - group.Sum(item => item.Credit)
+                        : group.Sum(item => item.Credit) - group.Sum(item => item.Debit));
+
+            var trend = new List<DashboardTrendPointDto>();
+            var cursor = new DateTime(rangeStart.Year, rangeStart.Month, 1);
+            var endMonth = new DateTime(rangeEnd.Year, rangeEnd.Month, 1);
+
+            while (cursor <= endMonth)
+            {
+                monthlyAmounts.TryGetValue(cursor, out var amount);
+
+                trend.Add(new DashboardTrendPointDto
+                {
+                    Label = cursor.ToString("MMM", CultureInfo.InvariantCulture),
+                    Amount = amount
+                });
+
+                cursor = cursor.AddMonths(1);
+            }
+
+            return trend;
+        }
+
+        private static decimal ComputeNetAmount(
+            IEnumerable<MasterGeneralLedger> ledger,
+            ISet<int> accountIds,
+            bool normalBalanceIsDebit)
+        {
+            var filtered = ledger.Where(line => accountIds.Contains(line.AccountId));
+
+            return normalBalanceIsDebit
+                ? filtered.Sum(line => line.Debit) - filtered.Sum(line => line.Credit)
+                : filtered.Sum(line => line.Credit) - filtered.Sum(line => line.Debit);
+        }
+
+        private static List<DashboardActivityItemDto> BuildRecentActivity(
+            IEnumerable<Core.Domain.Sales.SalesInvoiceHeader> salesInvoices,
+            IEnumerable<Core.Domain.Sales.SalesReceiptHeader> salesReceipts,
+            IEnumerable<Core.Domain.Purchases.PurchaseInvoiceHeader> purchaseInvoices,
+            int recentActivity)
+        {
+            var items = new List<DashboardActivityItemDto>();
+
+            items.AddRange(salesInvoices.Select(invoice => new DashboardActivityItemDto
+            {
+                Type = "SalesInvoice",
+                Description = $"Sales invoice {invoice.No} for {invoice.Customer?.Party?.Name ?? "customer"}",
+                Date = invoice.Date
+            }));
+
+            items.AddRange(salesReceipts.Select(receipt => new DashboardActivityItemDto
+            {
+                Type = "SalesReceipt",
+                Description = $"Payment received on receipt {receipt.No}",
+                Date = receipt.Date
+            }));
+
+            items.AddRange(purchaseInvoices.Select(invoice => new DashboardActivityItemDto
+            {
+                Type = "PurchaseInvoice",
+                Description = $"Purchase invoice {invoice.No} from {invoice.Vendor?.Party?.Name ?? "vendor"}",
+                Date = invoice.Date
+            }));
+
+            return items
+                .OrderByDescending(item => item.Date)
+                .Take(recentActivity)
+                .ToList();
+        }
+    }
+}

--- a/src/Services/Dashboard/IDashboardService.cs
+++ b/src/Services/Dashboard/IDashboardService.cs
@@ -1,0 +1,15 @@
+using System;
+using Dto.Dashboard;
+
+namespace Services.Dashboard
+{
+    public interface IDashboardService
+    {
+        DashboardSummaryDto GetDashboardSummary(
+            DateTime? from = null,
+            DateTime? to = null,
+            int topReceivables = 5,
+            int topPayables = 5,
+            int recentActivity = 5);
+    }
+}

--- a/src/src.AppHost/src.AppHost.csproj
+++ b/src/src.AppHost/src.AppHost.csproj
@@ -1,6 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.0.1" />
+<Project Sdk="Aspire.AppHost.Sdk/13.2.1">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,8 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.0.1" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.0.1" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.2.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds a implementation of the end to end dashboard implementation for the accounting app. 

It introduces a dedicated dashboard API endpoint and service to aggregate summary data for the UI, then wires the MVC dashboard page to consume that data and display KPI cards, charts, receivables, payables, and recent activity. It also adds demo seed data so the dashboard can be tested locally with non-empty values.

Changes
-added dashboard DTOs
-added dashboard service and API endpoint
-connected the MVC dashboard page to the new API
-added demo seed data for local dashboard testing

