### PR TITLE
Fixed bug in donations edit page that would cause a null exeption, up…

### DIFF
--- a/src/AccountGoWeb/Components/Pages/Donations/DonationInvoices.razor
+++ b/src/AccountGoWeb/Components/Pages/Donations/DonationInvoices.razor
@@ -337,7 +337,7 @@ else
         SelectInvoice(invoice);
         if (selectedInvoice != null)
         {
-            NavigationManager.NavigateTo($"/donations/donationinvoice?id={selectedInvoice.Id}", forceLoad: true);
+            NavigationManager.NavigateTo($"/donations/donationinvoice/{selectedInvoice.Id}", forceLoad: true);
         }
     }
 
@@ -345,7 +345,7 @@ else
     {
         if (selectedInvoice != null)
         {
-            NavigationManager.NavigateTo($"/donations/donationinvoice?id={selectedInvoice.Id}");
+            NavigationManager.NavigateTo($"/donations/donationinvoice/{selectedInvoice.Id}");
         }
     }
 
@@ -368,7 +368,7 @@ else
         {
             try
             {
-                NavigationManager.NavigateTo($"/donations/deletedonationinvoice?id={selectedInvoice.Id}");
+                NavigationManager.NavigateTo($"/donations/deletedonationinvoice/{selectedInvoice.Id}");
                 showDeleteModal = false;
             }
             catch (Exception ex)

--- a/src/AccountGoWeb/Controllers/DonationsController.cs
+++ b/src/AccountGoWeb/Controllers/DonationsController.cs
@@ -130,6 +130,12 @@ namespace AccountGoWeb.Controllers
             else
             {
                 donationInvoiceModel = GetAsync<DonationInvoice>("Donations/DonationInvoice?id=" + id).Result;
+
+                if (donationInvoiceModel == null)
+                {   
+                    return RedirectToAction("DonationInvoices");
+                }
+
                 ViewBag.Id = donationInvoiceModel.Id;
                 ViewBag.DonorName = donationInvoiceModel.DonorName;
                 ViewBag.DonationDate = donationInvoiceModel.DonationDate;


### PR DESCRIPTION
…dated routing to use route parameters instead of a query string.

Routing is now updated so instead of : 
http://localhost:8000/donations/donationinvoice?id=1

it uses the cleaner:
http://localhost:8000/donations/donationinvoice/1

The issue where entering an invalid ID in the URL causing a null exception has been fixed, if a non existent donation is attempted to be loaded the user will instead be returned back to the donation list view.