### PR TITLE
fix: apply all pending migrations on every startup

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -90,16 +90,10 @@ using (var scope = app.Services.CreateScope())
     var services = scope.ServiceProvider;
 
     var apiDbContext = services.GetRequiredService<ApiDbContext>();
-    if (!apiDbContext.Database.GetAppliedMigrations().Any())
-    {
-        apiDbContext.Database.Migrate();
-    }
+    apiDbContext.Database.Migrate();
 
     var identityDbContext = services.GetRequiredService<ApplicationIdentityDbContext>();
-    if (!identityDbContext.Database.GetAppliedMigrations().Any())
-    {
-        identityDbContext.Database.Migrate();
-    }
+    identityDbContext.Database.Migrate();
 
     var seeder = services.GetRequiredService<DatabaseSeeder>();
     seeder.Seed();


### PR DESCRIPTION
## Problem
Issues #275-280 only occur in the deployed app, not locally. Root cause: migration logic bug in `src/Api/Program.cs`.

## Root Cause
The code checked if ANY migrations existed before running migrations:
```csharp
{
    apiDbContext.Database.Migrate();
}
```

This prevents all new migrations from being applied once the database is already migrated—a classic one-time execution bug.

## Solution
Remove the guard condition and always call `Database.Migrate()`. Entity Framework will safely handle checking what's already applied and only run pending migrations.

## Impact
This fix resolves all 6 failing issues by ensuring recent migrations are applied:
- Fixes #275: Donation Invoices now have required tables
- Fixes #276: Customers have required columns  
- Fixes #277: Purchase Orders have required fields
- Fixes #278: Vendor Invoices have required schema
- Fixes #279: Vendors have required data
- Fixes #280: Payments have required fields

## Testing
- Local `aspire run` already works (uses MigrationService)
- After merge and deploy: verify issues #275-280 are resolved