### PR TITLE
fix: use Windows PowerShell commands in GitHub Actions workflow

### DIFF
--- a/.github/workflows/gdbapi.yml
+++ b/.github/workflows/gdbapi.yml
@@ -37,9 +37,9 @@ jobs:
         run: |
           echo "++++ Checking existing migrations..."
           echo "++++ IdentityDb migrations:"
-          ls -la ./src/Api/Data/Migrations/IdentityDb/ || echo "IdentityDb migration directory not found"
+          dir ./src/Api/Data/Migrations/IdentityDb/ 2>$null || echo "IdentityDb migration directory not found"
           echo "++++ ApiDb migrations:"
-          ls -la ./src/Api/Data/Migrations/ApiDb/ || echo "ApiDb migration directory not found"
+          dir ./src/Api/Data/Migrations/ApiDb/ 2>$null || echo "ApiDb migration directory not found"
 
       - name: dotnet publish API
         run: |


### PR DESCRIPTION
## Problem
The API deployment workflow failed with:
```
Get-ChildItem: D:\a\_temp\b3edd55d-aac5-4b61-8ee4-8ad13ee7c808.ps1:4
Line | 4 |  ls -la ./src/Api/Data/Migrations/IdentityDb/ || echo "IdentityDb migr …
     |     ~~~
     | A parameter cannot be found that matches parameter name 'la'.
```

## Root Cause
The workflow runs on `windows-latest` (PowerShell) but used Unix/Linux commands (`ls -la`) which PowerShell doesn't understand.

## Solution
Replace Unix commands with Windows-compatible PowerShell commands:
- `ls -la` → `dir` (Windows command)
- `|| echo` → `2>$null || echo` (PowerShell null redirection)

## Files Changed
- `.github/workflows/gdbapi.yml`: Fixed migration verification step to use Windows commands

This is a critical fix - without this, the API deployment workflow cannot run on Windows.
