### PR TITLE
fix: add database creation with retry logic before migrations

### DIFF
--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -90,6 +90,26 @@ using (var scope = app.Services.CreateScope())
     var services = scope.ServiceProvider;
 
     var apiDbContext = services.GetRequiredService<ApiDbContext>();
+    
+    // Ensure database exists before running migrations with retry logic
+    try
+    {
+        var dbCreator = apiDbContext.GetService<Microsoft.EntityFrameworkCore.Infrastructure.IRelationalDatabaseCreator>();
+        var strategy = apiDbContext.Database.CreateExecutionStrategy();
+        strategy.Execute(() =>
+        {
+            if (!dbCreator.Exists())
+            {
+                dbCreator.Create();
+            }
+        });
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine($"Error ensuring database exists: {ex.Message}");
+        throw;
+    }
+    
     apiDbContext.Database.Migrate();
 
     var identityDbContext = services.GetRequiredService<ApplicationIdentityDbContext>();


### PR DESCRIPTION
## Problem
The API was failing on Azure with:
```
SqlException: Execution Timeout Expired. The timeout period elapsed prior 
to completion of the operation or the server is not responding.
CREATE DATABASE operation failed. Internal service error.
```

This occurred when:
1. Database was deleted
2. App restarted
3. API tried to apply migrations but database didn't exist
4. Database creation timed out

## Root Cause
The migration logic in Program.cs was calling `Database.Migrate()` without first ensuring the database exists. This caused Entity Framework to try creating a database while simultaneously running migrations, leading to conflicts and timeouts.

## Solution
Add explicit database existence check and creation logic **before** migrations run, with retry logic for transient failures:

1. Check if database exists
2. If not, create it using Entity Framework's IRelationalDatabaseCreator
3. Use CreateExecutionStrategy() to automatically retry on transient failures
4. Then run migrations on the existing database

This matches the approach used in `MigrationService.Worker.cs` which has been working reliably.

## Changes
- `src/Api/Program.cs`: Add database creation with retry logic in the startup initialization

## Testing
- ✅ Local development (aspire run)
- ✅ Azure deployment with fresh database
- ✅ Database recreated from scratch

After merge, this will handle all scenarios:
- Fresh database creation
- Existing database with migrations already applied
- Database recreation (delete + restart)
